### PR TITLE
chore: cache Maven dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,13 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: 'Test'
         run: mvn --batch-mode install
 


### PR DESCRIPTION
Cache dependencies for faster CI build