### PR TITLE
chore: use fully-qualified jar names, so it is clear where the jar comes from

### DIFF
--- a/build-logic/publishing/src/main/kotlin/build-logic.java-published-library.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.java-published-library.gradle.kts
@@ -21,7 +21,7 @@ val extraMavenPublications by configurations.creating {
     isCanBeConsumed = false
 }
 
-val archivesName = "qubership-profiler-$name"
+val archivesName = "${isolated.rootProject.name}${path.replace(':', '-')}"
 base.archivesName.set(archivesName)
 
 publishing {

--- a/build-logic/publishing/src/main/kotlin/build-logic.java-published-platform.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.java-published-platform.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("build-logic.publish-to-central")
 }
 
-val archivesName = "qubership-profiler-$name"
+val archivesName = "${isolated.rootProject.name}${path.replace(':', '-')}"
 base.archivesName.set(archivesName)
 
 publishing {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 // This is the name of a current project
 // Note: it cannot be inferred from the directory name as developer might clone the project to folder with any name
-rootProject.name = "qubership-profiler-agent"
+rootProject.name = "qubership-profiler"
 
 includeBuild("build-logic")
 


### PR DESCRIPTION
E.g. the jars will be like `qubership-profiler-boot.jar`, `qubership-profiler-plugins-ant.jar`, and so on.
