### PR TITLE
chore: create git tag, and publish GitHub releases

### DIFF
--- a/.github/actions/update_version/action.yaml
+++ b/.github/actions/update_version/action.yaml
@@ -1,0 +1,26 @@
+name: bump version in gradle.properties
+inputs:
+  version:
+    required: true
+    description: new version
+
+runs:
+  using: composite
+  steps:
+    - name: update version
+      shell: bash
+      # language=bash
+      run: |
+        # Check if version needs to be updated
+        VERSION_LINE="profiler.version=${{ inputs.version }}"
+        if grep -q "^${VERSION_LINE}$" gradle.properties; then
+          echo "Version is already up to date"
+        else
+          # Update version in gradle.properties
+          sed -i "s/^profiler\.version=.*$/${VERSION_LINE}/" gradle.properties
+
+          # Commit and push changes
+          git add gradle.properties
+          git commit -m "chore: bump version to ${{ inputs.version }}" -m "[ci-skip]"
+          git push origin ${{ inputs.branch_name }}
+        fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,24 +4,101 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        required: true
-        default: ''
+        required: false
         type: string
-        description: new version number, without leading v
+        default: ''
+        description: Release version number (without v, defaults to gradle.properties)
+
 jobs:
-  release-to-central:
+  publish-release:
+    name: Publish release
     runs-on: ubuntu-latest
+    permissions:
+      # write permission is required to create a GitHub release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: read
     steps:
+      - name: Validate input parameters
+        # language=bash
+        run: |
+          # Ensure we release from main or release/** branches, ensure version number follows semver
+          BRANCH_NAME=${GITHUB_REF##refs/heads/}
+          if [[ ! "$BRANCH_NAME" =~ ^(main|release/.+)$ ]]; then
+            echo "Error: Release must be created from 'main' or 'release/**' branch. Current branch is '$BRANCH_NAME'"
+            exit 1
+          fi
+
+          # Validate version follows semver or is empty
+          VERSION="${{ inputs.version }}"
+          if [[ -n "$VERSION" && ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must be blank or follow semantic versioning format (x.y.z). Got '$VERSION'"
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # TODO: create and push git tag
-      # TODO: publish GitHub release (automatic? manual?)
+      - name: Get the release version
+        id: release_version
+        shell: bash
+        # language=bash
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+            echo "Got release version from workflow input: $VERSION"
+          else
+            VERSION=$(grep "^profiler.version=" gradle.properties | cut -d'=' -f2)
+            echo "Got release version from gradle.properties: $VERSION"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Check if tag exists
+        uses: actions/github-script@v7
+        env:
+          VERSION: ${{ steps.release_version.outputs.version }}
+        with:
+          # language=javascript
+          script: |
+             const tag = `v${process.env.VERSION}`;
+             // Check if the tag exists
+             const { data: tags } = await github.rest.git.listMatchingRefs({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 ref: `tags/${tag}`
+             });
+             if (tags.length > 0) {
+                 core.setFailed(`Tag ${tag} already exists. Bump version in gradle.properties and try releasing again.`);
+             }
+
+      - name: Prepare git name and email
+        # language=bash
+        run: |
+          # Configure git user.name and user.email
+          # See https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update version in gradle.properties to ${{ steps.release_version.outputs.version }}
+        uses: ./.github/actions/update_version
+        with:
+          version: ${{ steps.release_version.outputs.version }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+          server-id: central
+
+      # Publish to Central before generating a tag, so we don't need to drop the tag if
+      # Central deployment fails.
       - name: Publish to Central Portal
         uses: burrunan/gradle-cache-action@v1
         with:
           arguments: publishAggregationToCentralPortal
+          # language=properties
           properties: |
             release=true
             centralPortalPublishingType=USER_MANAGED
@@ -30,3 +107,29 @@ jobs:
           CENTRAL_PORTAL_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           SIGNING_PGP_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           SIGNING_PGP_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Publish GitHub release
+        uses: release-drafter/release-drafter@v6
+        id: publish_release
+        with:
+          disable-autolabeler: true
+          publish: true
+          latest: ${{ github.ref_name == github.event.repository.default_branch }}
+          version: ${{ steps.release_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute the next patch version
+        id: next_version
+        # language=bash
+        run: |
+          # Compute the next patch version
+          IFS='.' read -r major minor patch <<< "${{ steps.release_version.outputs.version }}"
+          next_version="${major}.${minor}.$((patch + 1))"
+          echo "Next version: $next_version"
+          echo "version=$next_version" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in gradle.properties to ${{ steps.next_version.outputs.version }}
+        uses: ./.github/actions/update_version
+        with:
+          version: ${{ steps.next_version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -95,3 +95,27 @@ To build all components just checkout source code, navigate to checkout director
 ```bash
 mvn clean install
 ```
+
+## Releasing Qubership Profiler
+
+This project defines a [manual release workflow](.github/workflows/release.yaml).
+
+To trigger a release, go to the
+👉 [Actions tab → release.yaml](https://github.com/Netcracker/qubership-profiler-agent/actions/workflows/release.yaml) and run it manually.
+
+The release workflow uses [Release Drafter](https://github.com/release-drafter/release-drafter) to prepare
+release notes, and it uses labels to group the changes. If you need to adjust the notes, update the labels as needed.
+
+Here's the full step-by-step:
+1. Navigate to [Release Workflow](https://github.com/Netcracker/qubership-profiler-agent/actions/workflows/release.yaml)
+1. Click on `Run workflow`
+1. Select the branch name to be released
+1. By default, release workflow would pick the release version from `gradle.properties`, and you can overrided it if needed
+1. Click on `Run workflow`
+
+The release workflow would perform the following steps:
+1. Check if the release tag `v...` does not exist yet, otherwise it would terminate
+1. Bump the version in `gradle.properties` to the release version (e.g., if the manually provided version differs)
+1. Build and publish the artifacts to Central Portal
+1. Create the release tag and publish GitHub release
+1. Bump the version in `gradle.properties` to the next patch version


### PR DESCRIPTION
This adds automatic release workflow that generates tags, publishes GitHub releases, publishes to Central Portal.

The key ideas:
* Version is stored in `gradle.properties`, and the workflow uses it when publishing releases
* Version should not include `-SNAPSHOT` suffix, and the build scripts add `-SNAPSHOT` by default unless `-Prelease` command option exists
* The documentation on release steps is currently located in readme
* Releasing old versions is supported as well via creating `release/1.0.x`, `release/1.x` branches. Note: release workflow should exist on the release branch as well.

I've tested the workflow with my fork, and it works as expected.