### PR TITLE
chore: add gradle/actions/dependency-submission so GitHub could alert about dependency vulnerabilities

### DIFF
--- a/.github/workflows/gradle-dependency-submit.yaml
+++ b/.github/workflows/gradle-dependency-submit.yaml
@@ -1,0 +1,27 @@
+name: Dependency Submission
+
+# See https://github.com/gradle/actions/blob/768a17f3488dc3fe0155ff431553e1f53d57e22e/dependency-submission/README.md#the-dependency-submission-action
+# The action allows GitHub to alert about reported vulnerabilities in the project
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    name: Submit dependencies
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        distribution: zulu
+        java-version: 17
+        server-id: central
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@v4


### PR DESCRIPTION
### Describe Your Changes

The action resolves all project dependencies, so it enables GitHub to list dependencies and detect vulnerabilities.
See https://github.com/Netcracker/qubership-profiler-agent/network/dependencies

### Checklist

The following checks are **mandatory**:

* [x] My change adheres [Qubership contributing guidelines](/CONTRIBUTING.md).
