### PR TITLE
chore: bump jackson to 2.19.0 to fix CVEs

### DIFF
--- a/bom-thirdparty/build.gradle.kts
+++ b/bom-thirdparty/build.gradle.kts
@@ -9,6 +9,7 @@ javaPlatform {
 }
 
 dependencies {
+    api(platform("com.fasterxml.jackson:jackson-bom:2.19.0"))
     api(platform("org.ow2.asm:asm-bom:9.8"))
     api(platform("org.springframework.boot:spring-boot-dependencies:1.5.22.RELEASE"))
     constraints {

--- a/common/src/main/java/org/qubership/profiler/formatters/title/DataFlowTitleFormatter.java
+++ b/common/src/main/java/org/qubership/profiler/formatters/title/DataFlowTitleFormatter.java
@@ -91,7 +91,7 @@ public class DataFlowTitleFormatter extends AbstractTitleFormatter {
             DFSession session = new DFSession();
             for (JsonToken token = parser.nextToken(); token != null; token = parser.nextToken()) {
                 if (token == JsonToken.VALUE_STRING) {
-                    switch (parser.getCurrentName()) {
+                    switch (parser.currentName()) {
                         case "t":
                             session.t = parser.getText();
                             break;


### PR DESCRIPTION
### Describe Your Changes

Previously, jackson was coming from spring bom, and spring 1.5 is no longer updated.

### Checklist

The following checks are **mandatory**:

* [x] My change adheres [Qubership contributing guidelines](/CONTRIBUTING.md).
