### PR TITLE
chore: exclude :plugins:... from dependency upgrades

### DIFF
--- a/.github/workflows/gradle-dependency-submit.yaml
+++ b/.github/workflows/gradle-dependency-submit.yaml
@@ -25,3 +25,9 @@ jobs:
         server-id: central
     - name: Generate and submit dependency graph
       uses: gradle/actions/dependency-submission@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4
+      with:
+        # Profiler plugins do not expose the dependencies to the runtime, so the versions used for the build
+        # do not affect the execution. At the same time, we might need to build plugins for different thirdparty
+        # versions, so we intentionally exclude :plugins:* projects from the submitted dependencies
+        dependency-graph-exclude-projects: |
+          :plugins:.*

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,10 @@
   "schedule": [
     "every 3 weeks on Monday"
   ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "plugins/*/build.gradle.kts"
+  ],
   "packageRules": [
     {
       "groupName": "checkerframework",


### PR DESCRIPTION
Profiler plugins do not expose the dependencies to the runtime, so the versions used for the build do not affect the execution. At the same time, we might need to build plugins for different thirdparty versions, so we intentionally exclude :plugins:* projects from the submitted dependencies
