### PR TITLE
chore: use special push token to bypass the push rule

### DIFF
--- a/.github/actions/update_version/action.yaml
+++ b/.github/actions/update_version/action.yaml
@@ -3,24 +3,41 @@ inputs:
   version:
     required: true
     description: new version
+  token:
+    required: true
+    description: token to use when
 
 runs:
   using: composite
   steps:
+    - name: Update the worktree
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref_name }}
+        token: ${{ inputs.token }}
+        persist-credentials: true
+
     - name: update version
       shell: bash
       # language=bash
       run: |
-        # Check if version needs to be updated
+        # Check if version needs to be updated to ${{ inputs.version }}
         VERSION_LINE="profiler.version=${{ inputs.version }}"
         if grep -q "^${VERSION_LINE}$" gradle.properties; then
           echo "Version is already up to date"
-        else
-          # Update version in gradle.properties
-          sed -i "s/^profiler\.version=.*$/${VERSION_LINE}/" gradle.properties
-
-          # Commit and push changes
-          git add gradle.properties
-          git commit -m "chore: bump version to ${{ inputs.version }}" -m "[ci-skip]"
-          git push origin ${{ inputs.branch_name }}
+          exit 0
         fi
+
+        # Update version in gradle.properties
+        sed -i "s/^profiler\.version=.*$/${VERSION_LINE}/" gradle.properties
+
+        # Commit and push changes
+        git add gradle.properties
+        git commit -m "chore: bump version to ${{ inputs.version }}" -m "[ci-skip]"
+        git push origin "${{ github.ref_name }}"
+
+    - name: Update the worktree, revert to the default token
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref_name }}
+        token: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,9 +80,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app-id: ${{ vars.GH_BUMP_VERSION_APP_ID }}
+          private-key: ${{ secrets.GH_BUMP_VERSION_APP_KEY }}
+
       - name: Update version in gradle.properties to ${{ steps.release_version.outputs.version }}
         uses: ./.github/actions/update_version
         with:
+          token: ${{ steps.app_token.outputs.token }}
           version: ${{ steps.release_version.outputs.version }}
 
       - name: Set up JDK 17
@@ -132,4 +139,5 @@ jobs:
       - name: Update version in gradle.properties to ${{ steps.next_version.outputs.version }}
         uses: ./.github/actions/update_version
         with:
+          token: ${{ steps.app_token.outputs.token }}
           version: ${{ steps.next_version.outputs.version }}


### PR DESCRIPTION
### Describe Your Changes

Allows version bump from release workflow and keep branch protection rules at the same time.
