### PR TITLE
fix: add default configuration to the agent installer

### DIFF
--- a/build-logic/basics/src/main/kotlin/configureToolchain.kt
+++ b/build-logic/basics/src/main/kotlin/configureToolchain.kt
@@ -1,4 +1,5 @@
 import org.gradle.api.provider.Provider
+import org.gradle.jvm.toolchain.JavaCompiler
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
@@ -7,6 +8,10 @@ import org.gradle.jvm.toolchain.JvmImplementation
 import org.gradle.jvm.toolchain.JvmVendorSpec
 
 fun JavaToolchainService.launcherFor(jdk: ToolchainProperties): Provider<JavaLauncher> = launcherFor {
+    configureToolchain(jdk)
+}
+
+fun JavaToolchainService.compilerFor(jdk: ToolchainProperties): Provider<JavaCompiler> = compilerFor {
     configureToolchain(jdk)
 }
 

--- a/build-logic/jvm/src/main/kotlin/build-logic.profiler-plugin.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.profiler-plugin.gradle.kts
@@ -69,6 +69,9 @@ val generateInjectorClassesDir = layout.buildDirectory.dir("generated-injector-c
 
 val compileInjector by tasks.registering(JavaCompile::class) {
     dependsOn(generateInjector)
+    buildParameters.buildJdk?.let {
+        javaCompiler.set(javaToolchains.compilerFor(it))
+    }
     source(generateInjectorDir)
     classpath = injectorCompileClasspath
     destinationDirectory.set(generateInjectorClassesDir)

--- a/installer/build.gradle.kts
+++ b/installer/build.gradle.kts
@@ -68,7 +68,10 @@ dependencies {
 val installerZip by tasks.registering(Zip::class) {
     from(sourceSets.main.get().resources)
     into("lib") {
-        from(installerZipFiles)
+        from(installerZipFiles) {
+            // Remove "-$version" suffix from the jar names as the profiler does not expect files with versions
+            rename("""-\d+\.\d+(?:.(?!jar$))+""", "")
+        }
     }
     // TODO: do we really need extracting the config files? Could the agent look into the jars?
     into(".") {

--- a/installer/src/main/resources/config/_config.filters.xml
+++ b/installer/src/main/resources/config/_config.filters.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiler-configuration>
+    <ruleset>
+        <rule id="filter-rule" src="_config.filters.default.xml"/>
+    </ruleset>
+</profiler-configuration>

--- a/installer/src/main/resources/config/_config.xml
+++ b/installer/src/main/resources/config/_config.xml
@@ -18,4 +18,7 @@
             <do-not-profile/>
         </rule>
     </ruleset>
+    <ruleset>
+        <rule src="_config.filters.xml"/>
+    </ruleset>
 </profiler-configuration>

--- a/installer/src/main/resources/config/default/25pre/include-minimal.xml
+++ b/installer/src/main/resources/config/default/25pre/include-minimal.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profiler-configuration>
+    <ruleset>
+        <rule src="../../minimal"/>
+    </ruleset>
+</profiler-configuration>

--- a/installer/src/main/resources/config/default/75post/qubership.generic.xml
+++ b/installer/src/main/resources/config/default/75post/qubership.generic.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profiler-configuration>
+    <ruleset>
+        <rule>
+            <class>org.qubership.**</class>
+            <minimum-method-size>50</minimum-method-size>
+        </rule>
+    </ruleset>
+</profiler-configuration>

--- a/installer/src/main/resources/config/logback.xml
+++ b/installer/src/main/resources/config/logback.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration scan="true" scanPeriod="30 seconds">
+  <!--<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">-->
+    <!--<file>logs/execution-statistics-collector-${org.qubership.profier.serverName}.log</file>-->
+    <!--<Append>true</Append>-->
+    <!--<rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">-->
+      <!--<FileNamePattern>logs/execution-statistics-collector-${org.qubership.profier.serverName}.log.%i.zip</FileNamePattern>-->
+      <!--<MinIndex>1</MinIndex>-->
+      <!--<MaxIndex>5</MaxIndex>-->
+    <!--</rollingPolicy>-->
+    <!--<triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">-->
+      <!--<MaxFileSize>5MB</MaxFileSize>-->
+    <!--</triggeringPolicy>-->
+    <!--<layout class="ch.qos.logback.classic.PatternLayout">-->
+      <!--<Pattern>%date %relative %level [%thread] %logger{10} %msg%n</Pattern>-->
+    <!--</layout>-->
+  <!--</appender>-->
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>%date %relative %logger{10} %msg%n</Pattern>
+    </layout>
+  </appender>
+
+  <root>
+    <level value="info" />
+    <appender-ref ref="STDOUT" />
+    <!--<appender-ref ref="FILE" />-->
+  </root>
+</configuration>

--- a/instrumenter/src/main/java/org/qubership/profiler/configuration/ConfigurationImpl.java
+++ b/instrumenter/src/main/java/org/qubership/profiler/configuration/ConfigurationImpl.java
@@ -75,7 +75,6 @@ public class ConfigurationImpl implements ConfigurationSPI {
     public ConfigurationImpl(String configFile) throws ParserConfigurationException, IOException, SAXException {
         //noinspection unchecked
         this.enhancerPlugins = (Map) Bootstrap.getPlugin(EnhancerRegistryPlugin.class).getEnhancersMap();
-        log.debug("Loading configuration from {}", configFile);
         this.configFile = configFile;
         parseFile(configFile);
         String verifyClassesProp = PropertyFacadeBoot.getProperty(Profiler.class.getName() + ".verify-classes", null);
@@ -93,6 +92,7 @@ public class ConfigurationImpl implements ConfigurationSPI {
     }
 
     private void parseFile(File file) throws ParserConfigurationException, IOException, SAXException {
+        log.debug("Loading configuration from {}", file.getAbsolutePath());
         final String fileName = file.getName();
         String overrideFileName;
         if ("super".equalsIgnoreCase(fileName)) {


### PR DESCRIPTION
### Describe Your Changes

This enables default instrumentation for services.
Tested with https://github.com/Netcracker/qubership-core-core-operator.git (`java -jar quarkus-run.jar`)