### PR TITLE
feat: make root level configurable with a property/environment variable

### DIFF
--- a/installer/src/main/resources/config/logback.xml
+++ b/installer/src/main/resources/config/logback.xml
@@ -23,7 +23,7 @@
   </appender>
 
   <root>
-    <level value="info" />
+    <level value="${org.qubership.profier.log.root_level:-info}" />
     <appender-ref ref="STDOUT" />
     <!--<appender-ref ref="FILE" />-->
   </root>


### PR DESCRIPTION
`org.qubership.profier.log.root_level` could configure the logging level
