### PR TITLE
chore: group org.openjdk.jmc version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,12 @@
       ]
     },
     {
+      "groupName": "org.openjdk.jmc",
+      "matchPackageNames": [
+        "org.openjdk.jmc{/,}**"
+      ]
+    },
+    {
       "description": "logback 1.3.0 requires slf4j-api 2.0+, and we want using slf4j 1.7",
       "groupName": "logback",
       "allowedVersions": "< 1.3.0",


### PR DESCRIPTION
### Describe Your Changes

Previously, Renovate updated `org.openjdk.jmc:common` and `org.openjdk.jmc:flightrecorder` in different PRs.