### PR TITLE
test: add integration test with qubership-core-base-images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,8 +22,15 @@ jobs:
     env:
       CENTRAL_PORTAL_USERNAME: ${{ secrets.MAVEN_USER }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          fetch-depth: 50
+      - name: Checkout qubership-core-base-images
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          repository: Netcracker/qubership-core-base-images
+          path: installer/build/git/qubership-core-base-images
           fetch-depth: 50
       - name: Set up JDK 17
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4

--- a/bom-testing/build.gradle.kts
+++ b/bom-testing/build.gradle.kts
@@ -9,11 +9,13 @@ javaPlatform {
 }
 
 dependencies {
+    api(platform("org.junit:junit-bom:5.12.2"))
     constraints {
         api("com.beust:jcommander:1.82")
         api("junit:junit:4.13.2")
         api("org.jmockit:jmockit-coverage:1.23")
         api("org.jmockit:jmockit:1.49")
         api("org.mockito:mockito-core:5.18.0")
+        api("org.testcontainers:junit-jupiter:1.21.0")
     }
 }

--- a/build-logic/jvm/src/main/kotlin/build-logic.test-junit5.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.test-junit5.gradle.kts
@@ -8,18 +8,10 @@ plugins {
 }
 
 dependencies {
-    testImplementation(platform("org.junit:junit-bom:5.12.2"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
-    testImplementation("org.hamcrest:hamcrest:3.0")
-    testImplementation("org.hamcrest:hamcrest-junit:2.0.0.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    if ((project.findProperty("junit4") ?: "true").toString().toBoolean()) {
-        // Allow projects to opt-out of junit dependency, so they can be JUnit5-only
-        testImplementation("junit:junit:4.13.2")
-        testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
-    }
 }
 
 tasks.configureEach<Test> {

--- a/build-logic/verification/src/main/kotlin/build-logic.autostyle.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.autostyle.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 autostyle {
     kotlinGradle {
-        ktlint()
+        ktlint("0.40.0")
         trimTrailingWhitespace()
         endWithNewline()
     }

--- a/installer-zip-test/README.md
+++ b/installer-zip-test/README.md
@@ -1,3 +1,9 @@
-Executes tests with `-javaagent:.../qubership-profiler-agent.jar`, so it enables to test the following:
-* `installer.zip` contents: build system extracts the profiler from `installer.zip`
-* configuration files and the jar files in `installer.zip`: the profiler activates with `-javaagent:..`, so the configuration and the classes load like they would do with regular applications
+# Installer ZIP Test
+
+This module verifies the functionality of the `installer.zip` distribution by running tests with the
+`-javaagent:.../qubership-profiler-agent.jar` parameter. It validates:
+
+- Proper extraction and packaging of profiler components from `installer.zip`
+- Correct loading of configuration files and jar files in a production-like environment with Java agent enabled
+
+The tests ensure the profiler works correctly when loaded as a Java agent, simulating real application usage.

--- a/installer-zip-test/build.gradle.kts
+++ b/installer-zip-test/build.gradle.kts
@@ -33,10 +33,12 @@ val extractInstaller by tasks.registering(Sync::class) {
 tasks.test {
     dependsOn(extractInstaller)
     // Execute tests with profiler
-    jvmArgumentProviders.add(CommandLineArgumentProvider {
-        listOf(
-            "-javaagent:${profilerHome.get().asFile.absolutePath}/lib/qubership-profiler-agent.jar"
-        )
-    })
+    jvmArgumentProviders.add(
+        CommandLineArgumentProvider {
+            listOf(
+                "-javaagent:${profilerHome.get().asFile.absolutePath}/lib/qubership-profiler-agent.jar"
+            )
+        }
+    )
     systemProperty("profiler.dump.home", layout.buildDirectory.dir("dump").map { it.asFile })
 }

--- a/installer/src/main/resources/config/logback.xml
+++ b/installer/src/main/resources/config/logback.xml
@@ -23,7 +23,7 @@
   </appender>
 
   <root>
-    <level value="${org.qubership.profier.log.root_level:-info}" />
+    <level value="${org.qubership.profiler.log.root_level:-info}" />
     <appender-ref ref="STDOUT" />
     <!--<appender-ref ref="FILE" />-->
   </root>

--- a/installer/src/test/java/org/qubership/profiler/test/agent/JavaBaseImageTest.java
+++ b/installer/src/test/java/org/qubership/profiler/test/agent/JavaBaseImageTest.java
@@ -1,0 +1,44 @@
+package org.qubership.profiler.test.agent;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+import java.time.Duration;
+
+@Testcontainers
+public class JavaBaseImageTest {
+    private static final String BASE_IMAGE_BUILD_ROOT = System.getProperty("qubership.profiler.test.java-base.root");
+    private static final String TESTAPP_JAR = System.getProperty("qubership.profiler.testapp.jar");
+
+    static {
+        assertNotNull(BASE_IMAGE_BUILD_ROOT, "qubership.profiler.test.java-base.root system property must be set");
+    }
+
+    @Test
+    void javaBaseDockerImageRuns() {
+        try (GenericContainer<?> container =
+                     new GenericContainer<>("qubership/qubership-core-base-image:profiler-latest")
+                             .withEnv("PROFILER_ENABLED", "true")
+                             .withCommand("java", "-jar", "/app/testapp.jar")
+                             .withCopyToContainer(MountableFile.forHostPath(TESTAPP_JAR), "/app/testapp.jar")
+                             .withStartupAttempts(1)
+                             .withStartupTimeout(Duration.ofMinutes(1))
+                             .withLogConsumer(new LogToConsolePrinter("[testApp] "))
+                             .withStartupCheckStrategy(new OneShotStartupCheckStrategy())
+        ) {
+            container.start();
+            // We don't assert the generated profiling output yet, however, we do verify the process starts successfully
+            String stderr = container.getLogs(OutputFrame.OutputType.STDERR);
+            if (!stderr.contains("-javaagent:")) {
+                fail("Container stderr should mention -javaagent: property");
+            }
+        }
+    }
+}

--- a/installer/src/test/java/org/qubership/profiler/test/agent/LogToConsolePrinter.java
+++ b/installer/src/test/java/org/qubership/profiler/test/agent/LogToConsolePrinter.java
@@ -1,0 +1,31 @@
+package org.qubership.profiler.test.agent;
+
+import org.testcontainers.containers.output.OutputFrame;
+
+import java.util.function.Consumer;
+
+/**
+ * Forwards Testcontainers output to the console, so it is easier to debug tests.
+ */
+public final class LogToConsolePrinter implements Consumer<OutputFrame> {
+    private final String prefix;
+
+    public LogToConsolePrinter(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    public void accept(OutputFrame outputFrame) {
+        String message = outputFrame.getUtf8String();
+        if (message.isEmpty()) {
+            return;
+        }
+        if (outputFrame.getType() == OutputFrame.OutputType.STDERR) {
+            System.err.print(prefix);
+            System.err.print(message);
+            return;
+        }
+        System.out.print(prefix);
+        System.out.print(message);
+    }
+}

--- a/installer/src/test/resources/logback.xml
+++ b/installer/src/test/resources/logback.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <root>
+        <level value="${org.qubership.profiler.log.root_level:-info}" />
+    </root>
+</configuration>

--- a/installer/src/testApp/java/org/qubership/profiler/testapp/Main.java
+++ b/installer/src/testApp/java/org/qubership/profiler/testapp/Main.java
@@ -1,0 +1,7 @@
+package org.qubership.profiler.testapp;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+}

--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -58,9 +58,11 @@ tasks.war {
         attributes["Web-ContextPath"] = "profiler"
     }
     from(sourceSets["launcher"].output)
-    from(configurations["launcherRuntimeClasspath"].elements.map { jars ->
-        jars.map { zipTree(it) }
-    }) {
+    from(
+        configurations["launcherRuntimeClasspath"].elements.map { jars ->
+            jars.map { zipTree(it) }
+        }
+    ) {
         duplicatesStrategy = DuplicatesStrategy.WARN
         // Tomcat jars are signed, and we can't reuse the signatures
         exclude("**/*.SF")


### PR DESCRIPTION
The test lauches a test application with qubership-core-base-images' profiler.

See the corresponding changes for the java-base image:
* https://github.com/Netcracker/qubership-core-base-images/pull/26
