### PR TITLE
chore: make helper "attribute" functions private in the build scripts

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.test-jmockit.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.test-jmockit.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 // https://github.com/gradle/gradle/pull/16627
-inline fun <reified T : Named> AttributeContainer.attribute(attr: Attribute<T>, value: String) =
+private inline fun <reified T : Named> AttributeContainer.attribute(attr: Attribute<T>, value: String) =
     attribute(attr, objects.named<T>(value))
 
 val jmockitAgent = configurations.dependencyScope("jmockitAgent")

--- a/installer-zip-test/build.gradle.kts
+++ b/installer-zip-test/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 val installerZipElements = configurations.dependencyScope("installerZipElements")
 
 // https://github.com/gradle/gradle/pull/16627
-inline fun <reified T : Named> AttributeContainer.attribute(attr: Attribute<T>, value: String) =
+private inline fun <reified T : Named> AttributeContainer.attribute(attr: Attribute<T>, value: String) =
     attribute(attr, objects.named<T>(value))
 
 val installerZip = configurations.resolvable("installerZip") {

--- a/installer/build.gradle.kts
+++ b/installer/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 // https://github.com/gradle/gradle/pull/16627
-inline fun <reified T : Named> AttributeContainer.attribute(attr: Attribute<T>, value: String) =
+private inline fun <reified T : Named> AttributeContainer.attribute(attr: Attribute<T>, value: String) =
     attribute(attr, objects.named<T>(value))
 
 val installerZipElements by configurations.dependencyScope("installerZipElements") {

--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -12,7 +12,7 @@ sourceSets {
 }
 
 // https://github.com/gradle/gradle/pull/16627
-inline fun <reified T : Named> AttributeContainer.attribute(attr: Attribute<T>, value: String) =
+private inline fun <reified T : Named> AttributeContainer.attribute(attr: Attribute<T>, value: String) =
     attribute(attr, objects.named<T>(value))
 
 val jsResourcesElements = configurations.dependencyScope("jsResourcesElements") {


### PR DESCRIPTION
kotlinc can't use compilation avoidance when there are public inline functions.
