### PR TITLE
chore: require Tomcat<10 and Sping Boot<3 for dependency upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,22 @@
       ]
     },
     {
+      "description": "Stick with Tomcat <10 since Tomcat 10+ requires jakarta migration which we can't afford yet",
+      "groupName": "Tomcat",
+      "allowedVersions": "< 10",
+      "matchPackageNames": [
+        "org.apache.tomcat{/,}**"
+      ]
+    },
+    {
+      "description": "Stick with org.springframework.boot <3 as we can't require Java 17 for the runtime yet",
+      "groupName": "Spring Boot",
+      "allowedVersions": "< 3",
+      "matchPackageNames": [
+        "org.springframework.boot{/,}**"
+      ]
+    },
+    {
       "description": "logback 1.3.0 requires slf4j-api 2.0+, and we want using slf4j 1.7",
       "groupName": "logback",
       "allowedVersions": "< 1.3.0",


### PR DESCRIPTION
We can't migrate the code from javax to jakarta since the generated war would be incompatible with Weblogic,
and we can't bump to Spring Boot 3 as it requires Java 17.

For the reference, Tomcat 9 is the latest one which supports JavaEE and which does not require migration to jakarta pacakges: https://tomcat.apache.org/whichversion.html