### PR TITLE
fix: Limit memory consumption by LocalBuffer

### DIFF
--- a/bom-thirdparty/build.gradle.kts
+++ b/bom-thirdparty/build.gradle.kts
@@ -11,7 +11,7 @@ javaPlatform {
 dependencies {
     api(platform("com.fasterxml.jackson:jackson-bom:2.19.0"))
     api(platform("org.ow2.asm:asm-bom:9.8"))
-    api(platform("org.springframework.boot:spring-boot-dependencies:1.5.22.RELEASE"))
+    api(platform("org.springframework.boot:spring-boot-dependencies:2.7.18"))
     constraints {
         api("backport-util-concurrent:backport-util-concurrent:3.1")
         api("ch.qos.logback:logback-classic:1.2.13")

--- a/boot/src/main/java/org/qubership/profiler/agent/LocalBuffer.java
+++ b/boot/src/main/java/org/qubership/profiler/agent/LocalBuffer.java
@@ -1,10 +1,16 @@
 package org.qubership.profiler.agent;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 public class LocalBuffer {
     public final static int SIZE = Integer.getInteger(LocalBuffer.class.getName() + ".SIZE", 4096);
     volatile public LocalState state;
+
+    public volatile long largeEventsVolume;
+    private static final AtomicLongFieldUpdater<LocalBuffer> LARGE_EVENTS_VOLUME_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(LocalBuffer.class, "largeEventsVolume");
+
     public LocalBuffer prevBuffer;
 
     public final long[] data = new long[SIZE];
@@ -22,6 +28,7 @@ public class LocalBuffer {
         startTime = TimerCache.now;
         count = 0;
         first = 0;
+        largeEventsVolume = 0;
         this.prevBuffer = prevBuffer;
     }
 
@@ -31,6 +38,9 @@ public class LocalBuffer {
         long[] data = this.data;
         if (r >= 0 && r < data.length) {
             data[r] = tagId | TimerCache.timerSHL32;
+            if (contents instanceof CharSequence) {
+                contents = truncateCharSequence(contents);
+            }
             value[r] = contents;
             count = r + 1;
         } else {
@@ -38,6 +48,19 @@ public class LocalBuffer {
             Profiler.exchangeBuffer(this);
             state.buffer.event(contents, tagId);
         }
+    }
+
+    private Object truncateCharSequence(Object contents) {
+        CharSequence s = (CharSequence) contents;
+        int length = s.length();
+        if (length > 4096) {
+            long total = LARGE_EVENTS_VOLUME_UPDATER.getAndAdd(this, length);
+            if (total > 100_000_000) {
+                LARGE_EVENTS_VOLUME_UPDATER.getAndAdd(this, -length);
+                contents = s.subSequence(0, 4049);
+            }
+        }
+        return contents;
     }
 
 //    public LocalState getLocalState(){

--- a/build-logic/build-parameters/build.gradle.kts
+++ b/build-logic/build-parameters/build.gradle.kts
@@ -38,6 +38,11 @@ buildParameters {
         mandatory.set(true)
         description.set("Java version for source and target compatibility")
     }
+    string("targetKotlinVersion") {
+        defaultValue.set("1.8")
+        mandatory.set(true)
+        description.set("Kotlin version for target compatibility")
+    }
     val projectName = "profiler"
     integer("jdkBuildVersion") {
         defaultValue.set(17)

--- a/build-logic/jvm/src/main/kotlin/build-logic.kotlin.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.kotlin.gradle.kts
@@ -16,8 +16,6 @@ java {
     withSourcesJar()
 }
 
-val String.v: String get() = rootProject.extra["$this.version"] as String
-
 autostyle {
     kotlin {
         file("$rootDir/config/licenseHeaderRaw").takeIf { it.exists() }?.let {
@@ -31,7 +29,7 @@ autostyle {
 tasks.configureEach<KotlinJvmCompile> {
     compilerOptions {
         if (!name.startsWith("compileTest")) {
-            apiVersion = KotlinVersion.fromVersion("kotlin.api".v)
+            apiVersion = KotlinVersion.fromVersion(buildParameters.targetKotlinVersion)
         }
         freeCompilerArgs.add("-Xjvm-default=all")
         val jdkRelease = buildParameters.targetJavaVersion.let {

--- a/installer-zip-test/build.gradle.kts
+++ b/installer-zip-test/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("build-logic.java-library")
+    id("build-logic.kotlin")
     id("build-logic.test-junit5")
     id("build-logic.test-jmockit")
 }

--- a/installer-zip-test/src/test/kotlin/org/qubership/profiler/reselience/OutOfMemoryStoringEventsTest.kt
+++ b/installer-zip-test/src/test/kotlin/org/qubership/profiler/reselience/OutOfMemoryStoringEventsTest.kt
@@ -1,0 +1,26 @@
+package org.qubership.profiler.reselience
+
+import org.junit.jupiter.api.Test
+import org.qubership.profiler.agent.Profiler
+
+class OutOfMemoryStoringEventsTest {
+    @Test
+    fun `add many large events works`() {
+        val value = "a".repeat(10_000_000)
+        Profiler.enter("OutOfMemoryStoringEventsTest.add many large events works")
+        try {
+            repeat(1000) {
+                Profiler.enter("OutOfMemoryStoringEventsTest.small method")
+                try {
+                    // Generate a new object so it consumes RAM
+                    val sb = StringBuilder(value)
+                    Profiler.event(sb, "xml")
+                } finally {
+                    Profiler.exit();
+                }
+            }
+        } finally {
+            Profiler.exit();
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Netcracker/qubership-profiler-agent/issues/171

### Describe Your Changes

The change includes the following:
* [x] limit the amount of information consumed by a single `LocalBuffer`
* [ ] make per-`LocalBuffer` limits configurable
* [ ] limit the amount of information consumed by all the `LocalBuffers`
* [ ] make global limit configurable
* [ ] ensure global limit is does not break if dumper thread restarts or buffers get discarded
