### PR TITLE
feat: bump Spring Boot to v2

### DIFF
--- a/bom-thirdparty/build.gradle.kts
+++ b/bom-thirdparty/build.gradle.kts
@@ -11,7 +11,7 @@ javaPlatform {
 dependencies {
     api(platform("com.fasterxml.jackson:jackson-bom:2.19.1"))
     api(platform("org.ow2.asm:asm-bom:9.8"))
-    api(platform("org.springframework.boot:spring-boot-dependencies:1.5.22.RELEASE"))
+    api(platform("org.springframework.boot:spring-boot-dependencies:2.7.18"))
     constraints {
         api("backport-util-concurrent:backport-util-concurrent:3.1")
         api("ch.qos.logback:logback-classic:1.2.13")

--- a/build-logic/publishing/build.gradle.kts
+++ b/build-logic/publishing/build.gradle.kts
@@ -8,4 +8,6 @@ dependencies {
     implementation(project(":build-parameters"))
     implementation("com.github.vlsi.gradle-extensions:com.github.vlsi.gradle-extensions.gradle.plugin:2.0.0")
     implementation("com.gradleup.nmcp:com.gradleup.nmcp.gradle.plugin:0.1.5")
+    implementation("com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:8.3.6")
+    implementation("org.apache.ant:ant:1.10.15")
 }

--- a/build-logic/publishing/src/main/kotlin/buildlogic/SpringFileTransformer.kt
+++ b/build-logic/publishing/src/main/kotlin/buildlogic/SpringFileTransformer.kt
@@ -1,0 +1,127 @@
+package buildlogic
+
+import com.github.jengelman.gradle.plugins.shadow.relocation.RelocateClassContext
+import com.github.jengelman.gradle.plugins.shadow.relocation.RelocatePathContext
+import com.github.jengelman.gradle.plugins.shadow.transformers.CacheableTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
+import org.gradle.api.file.FileTreeElement
+import java.io.StringWriter
+import java.util.*
+
+@CacheableTransformer
+class SpringFileTransformer : Transformer {
+    private val transformedProperties = mutableMapOf<String, Properties>()
+    private val supportedFiles = setOf(
+        "META-INF/spring-autoconfigure-metadata.properties",
+        "META-INF/spring.factories",
+        "META-INF/spring.handlers",
+        "META-INF/spring.schemas",
+        "META-INF/spring.tooling",
+    )
+
+    override fun getName(): String = "PropertyValuesFileTransformer"
+
+    override fun canTransformResource(element: FileTreeElement): Boolean {
+        return element.name in supportedFiles
+    }
+
+    override fun transform(context: TransformerContext) {
+        // Note: Resources that don't match patternSet should be skipped
+        // This is likely already handled by the Shadow plugin based on the canTransformResource method
+
+        // Parse the input file as Properties
+        val properties = Properties().apply {
+            load(context.`is`)
+        }
+
+        // Get or create Properties for this filename
+        val path = context.path
+        val filename = path
+        val props = transformedProperties.getOrPut(filename) { Properties() }
+
+        // Append all values to transformedProperties[filename]
+        for (key in properties.stringPropertyNames()) {
+            val value = properties.getProperty(key)
+            // factories: class=class
+            // handlers: url=class
+            // schemas: url=path
+            // tooling: url=path
+
+            val newKey = when {
+                path.endsWith("/spring.factories") -> context.relocateClass(key)
+                path.endsWith("/spring-autoconfigure-metadata.properties") -> context.relocateClass(key)
+                else -> key
+            }
+            val newValue = when {
+                path.endsWith("/spring.factories") || path.endsWith("/spring.handlers") || path.endsWith("/spring-autoconfigure-metadata.properties") ->
+                    value.split(",").joinToString(",") { context.relocateClass(it) }
+
+                path.endsWith("/spring.tooling") && key.endsWith("@icon") -> context.relocatePath(value)
+                path.endsWith("/spring.schemas") -> context.relocatePath(value)
+                else -> value
+            }
+            if (!props.containsKey(newKey) || props.getProperty(newKey).isNullOrBlank()) {
+                props.setProperty(newKey, newValue)
+            } else if (path.endsWith("/spring.factories") || path.endsWith("/spring.handlers") || path.endsWith("/spring-autoconfigure-metadata.properties")) {
+                if (newValue.isNotEmpty()) {
+                    val prevValue = props.getProperty(newKey)
+                    props.setProperty(newKey, "$prevValue,$newValue")
+                }
+            } else {
+                throw IllegalStateException(
+                    "Merging values for $path is not supported. Key=$newKey, previousValue=${
+                        props.getProperty(newKey)
+                    }, newValue=$newValue"
+                )
+            }
+        }
+    }
+
+    private fun TransformerContext.relocateClass(className: String): String {
+        relocators.forEach { relocator ->
+            if (relocator.canRelocateClass(className)) {
+                return relocator.relocateClass(RelocateClassContext.builder().className(className).stats(stats).build())
+            }
+        }
+        return className
+    }
+
+    private fun TransformerContext.relocatePath(pathName: String): String {
+        relocators.forEach { relocator ->
+            if (relocator.canRelocatePath(pathName)) {
+                return relocator.relocatePath(RelocatePathContext.builder().path(pathName).stats(stats).build())
+            }
+        }
+        return pathName
+    }
+
+    override fun hasTransformedResource(): Boolean {
+        return transformedProperties.isNotEmpty()
+    }
+
+    override fun modifyOutputStream(os: org.apache.tools.zip.ZipOutputStream, preserveFileTimestamps: Boolean) {
+        // Iterate over transformedProperties and append the needed zip entries
+        for ((path, properties) in transformedProperties) {
+            // Create a new zip entry for this path
+            val entry = org.apache.tools.zip.ZipEntry(path)
+            if (!preserveFileTimestamps) {
+                entry.time = 0
+            }
+            os.putNextEntry(entry)
+
+            // Write the properties to the zip entry
+            // Java properties creates a comment with the current date. We remove it to make the file reproducible
+            val sw = StringWriter()
+            properties.store(sw, null)
+            val cleanProperties = sw.toString().lineSequence()
+                .filter { !it.startsWith("#") }
+                .joinToString(System.lineSeparator())
+
+            os.write(cleanProperties.toByteArray(Charsets.ISO_8859_1))
+
+            // Close the entry
+            os.closeEntry()
+        }
+    }
+}

--- a/war-lib/build.gradle.kts
+++ b/war-lib/build.gradle.kts
@@ -1,4 +1,5 @@
-import com.github.jengelman.gradle.plugins.shadow.transformers.PropertiesFileTransformer
+import buildlogic.SpringFileTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 
 plugins {
     id("build-logic.java-published-library")
@@ -17,13 +18,11 @@ dependencies {
 
 tasks.shadowJar {
     mergeServiceFiles()
-    append("META-INF/spring.handlers")
-    append("META-INF/spring.schemas")
-    append("META-INF/spring.tooling")
-    append("META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports")
-    transform(PropertiesFileTransformer::class.java) {
-        paths.add("META-INF/spring.factories")
-        mergeStrategy = "append"
+    // spring-configuration-metadata.json is meant for IDEs
+    exclude("META-INF/spring-configuration-metadata.json")
+    transform(SpringFileTransformer::class.java)
+    transform(ServiceFileTransformer::class.java) {
+        include("META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports")
     }
     relocate("ch.qos.logback", "org.qubership.profiler.shaded.ch.qos.logback")
     relocate("com.fasterxml", "org.qubership.profiler.shaded.com.fasterxml")


### PR DESCRIPTION
Spring uses several files under `META-INF/spring.*`, and we need to relocate the values so they do not point to `org.springframework`, but they point to `org.qubership..shaded.org.spring`
