### PR TITLE
fix: remove stale "frame-buster" as it does not fully protect

### DIFF
--- a/profiler-ui/src/profiler.mjs
+++ b/profiler-ui/src/profiler.mjs
@@ -30,11 +30,6 @@ import 'dygraphs/dist/dygraph.css';
 import { default as Dygraph } from 'dygraphs';
 import { Activator } from './activate_ide.mjs';
 
-// Prevent cross-frame attack
-// This works as follows: if a page is opened inside a frame,
-if (top.frames.length != 0)
-  top.location = self.document.location;
-
 jQuery.fn.firstParents = function(n) {
     var matched = [];
     var t = this[0].parentNode;

--- a/web/src/main/java/org/qubership/profiler/filter/AddDefaultHeadersFilter.java
+++ b/web/src/main/java/org/qubership/profiler/filter/AddDefaultHeadersFilter.java
@@ -12,6 +12,9 @@ public class AddDefaultHeadersFilter implements Filter {
     public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws ServletException, IOException {
         if (resp instanceof HttpServletResponse) {
             HttpServletResponse res = (HttpServletResponse) resp;
+            if (!res.containsHeader("Content-Security-Policy")) {
+                res.setHeader("Content-Security-Policy", "frame-ancestors 'none'");
+            }
             res.setHeader("X-Frame-Options", "SAMEORIGIN");
             res.setHeader("X-XSS-Protection", "0");
             res.setHeader("X-content-Type-options", "nosniff");


### PR DESCRIPTION
That snippet is an old “frame-buster.”
It sometimes pops the page out of an iframe, but it’s not a reliable security control today.

Why it’s not reliable

* Easily bypassed: An attacker can put your page in <iframe sandbox> which
    blocks top.location navigation (unless allow-top-navigation/…-by-user-activation
    is granted). Many browsers also block programmatic top-nav without a user gesture.

* Wrong signal: top.frames.length != 0 doesn’t actually test “am I framed?”. It just
    checks whether the top page contains any frames. If your page is top-level and
    itself embeds an iframe (ads, widgets, etc.), this can trigger unnecessary reloads.
    The usual check is if (window.top !== window.self) { … }, but even that’s still
    bypassable for the reason above.

Limited scope: It only aims at clickjacking (UI redress). It doesn’t protect against XSS, CSRF, or cross-origin data access (the Same Origin Policy already blocks reads).

The modern approach is to add header `Content-Security-Policy: frame-ancestors 'none'`

See https://chatgpt.com/share/68b85d59-e1ac-800f-ab98-2403df6aea1b
