### PR TITLE
chore: revert Maven groupId com.netcracker.profiler -> org.qubership.profiler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ val jacocoReport by tasks.registering(JacocoReport::class) {
 }
 
 allprojects {
-    group = "com.netcracker.profiler"
+    group = "org.qubership.profiler"
     version = buildVersion
 }
 

--- a/profiler-ui/build.gradle.kts
+++ b/profiler-ui/build.gradle.kts
@@ -57,13 +57,13 @@ val jsResources = configurations.consumable("jsResources") {
         variants {
             create("prodResources") {
                 attributes {
-                    attribute(Attribute.of("com.netcracker.js.optimization", String::class.java), "prod")
+                    attribute(Attribute.of("com.netcracker.profler.js.optimization", String::class.java), "prod")
                 }
                 artifact(buildUi)
             }
             create("singlePage") {
                 attributes {
-                    attribute(Attribute.of("com.netcracker.js.optimization", String::class.java), "single-page")
+                    attribute(Attribute.of("com.netcracker.profler.js.optimization", String::class.java), "single-page")
                 }
                 artifact(buildTreeSinglepage)
             }

--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -22,7 +22,7 @@ val jsResources = configurations.resolvable("jsResources") {
     extendsFrom(jsResourcesElements.get())
     attributes {
         attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, LibraryElements.RESOURCES)
-        attribute(Attribute.of("com.netcracker.js.optimization", String::class.java), "prod")
+        attribute(Attribute.of("com.netcracker.profler.js.optimization", String::class.java), "prod")
     }
 }
 
@@ -30,7 +30,7 @@ val jsSinglePageResources = configurations.resolvable("jsSinglePageResources") {
     extendsFrom(jsResourcesElements.get())
     attributes {
         attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, LibraryElements.RESOURCES)
-        attribute(Attribute.of("com.netcracker.js.optimization", String::class.java), "single-page")
+        attribute(Attribute.of("com.netcracker.profler.js.optimization", String::class.java), "single-page")
     }
 }
 


### PR DESCRIPTION
https://github.com/Netcracker/qubership-profiler-agent/pull/277 was not supposed to change Maven group id
