### PR TITLE
chore: fix script injection issues in release workflow

### DIFF
--- a/.github/actions/update_version/action.yaml
+++ b/.github/actions/update_version/action.yaml
@@ -18,13 +18,16 @@ runs:
         token: ${{ inputs.token }}
         persist-credentials: true
 
-    - name: update version
+    - name: update version to ${{ inputs.version }}
       shell: bash
+      with:
+        VERSION: ${{ inputs.version }}
+        REF_NAME: ${{ github.ref_name }}
       # language=bash
       run: |
-        # Check if version needs to be updated to ${{ inputs.version }}
-        VERSION_LINE="profiler.version=${{ inputs.version }}"
-        if grep -q "^${VERSION_LINE}$" gradle.properties; then
+        # Check if version needs to be updated
+        VERSION_LINE="profiler.version=$VERSION"
+        if grep -Fqx -- "${VERSION_LINE}" gradle.properties; then
           echo "Version is already up to date"
           exit 0
         fi
@@ -34,8 +37,8 @@ runs:
 
         # Commit and push changes
         git add gradle.properties
-        git commit -m "chore: bump version to ${{ inputs.version }}" -m "[ci-skip]"
-        git push origin "${{ github.ref_name }}"
+        git commit -m "chore: bump version to $VERSION" -m "[ci-skip]"
+        git push origin "$REF_NAME"
 
     - name: Update the worktree, revert to the default token
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,8 @@ jobs:
       pull-requests: read
     steps:
       - name: Validate input parameters
+        env:
+          VERSION: ${{ inputs.version }}
         # language=bash
         run: |
           # Ensure we release from main or release/** branches, ensure version number follows semver
@@ -34,7 +36,6 @@ jobs:
           fi
 
           # Validate version follows semver or is empty
-          VERSION="${{ inputs.version }}"
           if [[ -n "$VERSION" && ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Version must be blank or follow semantic versioning format (x.y.z). Got '$VERSION'"
             exit 1
@@ -42,14 +43,17 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
 
       - name: Get the release version
         id: release_version
         shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
         # language=bash
         run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
+          if [[ -n "$VERSION" ]]; then
             echo "Got release version from workflow input: $VERSION"
           else
             VERSION=$(grep "^profiler.version=" gradle.properties | cut -d'=' -f2)
@@ -131,10 +135,12 @@ jobs:
 
       - name: Compute the next patch version
         id: next_version
+        env:
+          RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
         # language=bash
         run: |
           # Compute the next patch version
-          IFS='.' read -r major minor patch <<< "${{ steps.release_version.outputs.version }}"
+          IFS='.' read -r major minor patch <<< "$RELEASE_VERSION"
           next_version="${major}.${minor}.$((patch + 1))"
           echo "Next version: $next_version"
           echo "version=$next_version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
By default persist-credentials is true, so we improve security with this PR.