### PR TITLE
chore: publish diagtools to Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     nmcpAggregation(projects.boot)
     nmcpAggregation(projects.common)
     nmcpAggregation(projects.cli)
+    nmcpAggregation(projects.diagtools)
     nmcpAggregation(projects.dumper)
     nmcpAggregation(projects.installer)
     nmcpAggregation(projects.instrumenter)


### PR DESCRIPTION
Previously, the archive was prepared, however, the project itself was not listed for publishing.
