### PR TITLE
chore(ci): add step to install latest go version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,10 @@ jobs:
           distribution: zulu
           java-version: 21
           server-id: central
+      - name: Setup Go 1.25
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 #v6
+        with:
+          go-version: '>=1.25.0'
       - name: Test
         uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca # v3
         with:


### PR DESCRIPTION
### Describe Your Changes

We found the current build logic uses the built-in Go version in the `ubuntu-latest` image to build `diagtools`.
It can update Go to the minimal version specified in `go.mod`, but not to the latest version.

In Golang, various vulnerabilities are regularly found, so it makes sense to use the latest version of Golang to build binaries.
So I added the logic to install the latest Golang version in the build environment.

### Checklist

The following checks are **mandatory**:

* [x] My change adheres [Qubership contributing guidelines](/CONTRIBUTING.md).
