### PR TITLE
chore: update github/codeql-action/upload-sarif action hash for ossf-scorecard.yaml

### DIFF
--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -74,6 +74,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4
+        uses: github/codeql-action/upload-sarif@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
It fixes the following warning:

```
  warning[ref-version-mismatch]: detects commit SHAs that don't match their version comment tags
    --> /github/workspace/.github/workflows/ossf-scorecard.yaml:77:92
     |
  77 |         uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4
     |         --------------------------------------------------------------------------------   ^^ points to commit e12f0178983d
     |         |
     |         is pointed to by tag v4.31.2
     |
     = note: audit confidence → High

  3 findings (2 suppressed): 0 informational, 0 low, 1 medium, 0 high
```
