### PR TITLE
fix: replace org.lz4:lz4-java with at.yawk.lz4:lz4-java to fix CVE-2025-12183

### DIFF
--- a/bom-thirdparty/build.gradle.kts
+++ b/bom-thirdparty/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     api(platform("org.ow2.asm:asm-bom:9.9"))
     api(platform("com.google.inject:guice-bom:7.0.0"))
     constraints {
+        api("at.yawk.lz4:lz4-java:1.10.0")
         api("backport-util-concurrent:backport-util-concurrent:3.1")
         api("ch.qos.logback:logback-classic:1.5.20")
         api("ch.qos.logback:logback-core:1.5.20")
@@ -30,6 +31,11 @@ dependencies {
         api("org.apache.tomcat.embed:tomcat-embed-logging-juli:8.5.2")
         api("org.hdrhistogram:HdrHistogram:2.2.2")
         api("org.jspecify:jspecify:1.0.0")
+        api("org.lz4:lz4-java") {
+            version {
+                rejectAll()
+            }
+        }
         api("org.openjdk.jmc:common:8.3.1")
         api("org.openjdk.jmc:flightrecorder:8.3.1")
         api("org.slf4j:slf4j-api:2.0.17")

--- a/parsers/build.gradle.kts
+++ b/parsers/build.gradle.kts
@@ -12,8 +12,15 @@ dependencies {
     implementation("com.google.inject:guice")
     implementation("jakarta.servlet:jakarta.servlet-api")
     implementation("org.jspecify:jspecify")
-    implementation("org.openjdk.jmc:common")
-    implementation("org.openjdk.jmc:flightrecorder")
+    implementation("org.openjdk.jmc:common") {
+        exclude("org.lz4", "lz4-java")
+    }
+    implementation("org.openjdk.jmc:flightrecorder") {
+        exclude("org.lz4", "lz4-java")
+    }
+    runtimeOnly("at.yawk.lz4:lz4-java") {
+        because("org.openjdk.jmc:common needs lz4 decompressor, and we use at.yawk.lz4:lz4-java to fix CVE-2025-12183")
+    }
     testImplementation("org.mockito:mockito-core")
     testImplementation(projects.testkit)
 }

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -12,6 +12,13 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.google.inject.extensions:guice-servlet")
     implementation("com.google.inject:guice")
-    implementation("org.openjdk.jmc:common")
-    implementation("org.openjdk.jmc:flightrecorder")
+    implementation("org.openjdk.jmc:common") {
+        exclude("org.lz4", "lz4-java")
+    }
+    implementation("org.openjdk.jmc:flightrecorder") {
+        exclude("org.lz4", "lz4-java")
+    }
+    runtimeOnly("at.yawk.lz4:lz4-java") {
+        because("org.openjdk.jmc:common needs lz4 decompressor, and we use at.yawk.lz4:lz4-java to fix CVE-2025-12183")
+    }
 }


### PR DESCRIPTION
https://github.com/lz4/lz4-java is discontinued, and they suggest using the community for instead: https://github.com/yawkat/lz4-java
