### PR TITLE
fix: support jar:nested:... path in TypeUtils

### DIFF
--- a/common/src/main/java/com/netcracker/profiler/instrument/TypeUtils.java
+++ b/common/src/main/java/com/netcracker/profiler/instrument/TypeUtils.java
@@ -32,6 +32,7 @@ public class TypeUtils {
                 uri = location.toURI();
                 stringUri = uri.toString();
             } catch (java.net.URISyntaxException e) {
+                // especially for file:/u02/qubership/.../servers/clust1/tmp/_WL_user/Profiler/4jowy9/war/WEB-INF/lib/war-lib-9.3.3.2.jar
                 stringUri = location.toString();
             }
             if (stringUri == null) return null;
@@ -39,6 +40,10 @@ public class TypeUtils {
             if (stringUri.startsWith("jar:file:")) {
                 int endIdx = stringUri.endsWith("!/") ? stringUri.length() - 2 : stringUri.length();
                 file = new File(stringUri.substring("jar:file:".length(), endIdx));
+            } else
+            if (stringUri.startsWith("jar:nested:")) {
+                int endIdx = stringUri.endsWith("!/") ? stringUri.length() - 2 : stringUri.length();
+                file = new File(stringUri.substring("jar:nested:".length(), endIdx));
             } else
             if (stringUri.startsWith("file:")) {
                 file = new File(stringUri.substring("file:".length()));


### PR DESCRIPTION
This fixes the following:

```
2025-12-10 12:56:03,304 663 c.n.p.i.TypeUtils Unable to get jar name for protection domain ProtectionDomain  (jar:nested:/app/config-server.jar/!BOOT-INF/classes/!/ <no signer certificates>)
 org.springframework.boot.loader.launch.LaunchedClassLoader@72cde7cc
 <no principals>
 java.security.Permissions@13e344d (
 ("java.io.FilePermission" "/app/config-server.jar" "read")
)

, uri=jar:nested:/app/config-server.jar/!BOOT-INF/classes/!/ java.lang.IllegalArgumentException: URI is not hierarchical
    at java.base/java.io.File.<init>(File.java:420)
    at com.netcracker.profiler.instrument.TypeUtils.getFullJarName(TypeUtils.java:55)
    at com.netcracker.profiler.instrument.TypeUtils.getJarName(TypeUtils.java:85)
    at com.netcracker.profiler.agent.ProfilingTransformer.transform(ProfilingTransformer.java:115)
    at java.instrument/java.lang.instrument.ClassFileTransformer.transform(ClassFileTransformer.java:244)
    at java.instrument/sun.instrument.TransformerManager.transform(TransformerManager.java:188)
    at java.instrument/sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:610)
    at java.base/java.lang.ClassLoader.defineClass1(Native Method)
    at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1027)
    at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
    at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:524)
    at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:427)
```