### PR TITLE
feat: migrate threaddump and heapdump commands to jattach library

### DIFF
--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -5,3 +5,5 @@ JAVA_FILE_NAME=checkstyle.xml
 # Workaround for https://github.com/Netcracker/qubership-workflow-hub/issues/447
 VALIDATE_BIOME_FORMAT=false
 VALIDATE_BIOME_LINT=false
+# Enable CGO for Go linting (required for jattach library)
+CGO_ENABLED=1

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -69,7 +69,7 @@ jobs:
           cat .github/linters/super-linter.env .github/super-linter.env | grep -v '^#' | grep -vE '^\s*$' >> "$GITHUB_ENV" || true
 
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@47984f49b4e87383eed97890fe2dca6063bbd9c3 # v8.3.1
+        uses: super-linter/super-linter@47984f49b4e87383eed97890fe2dca6063bbd9c3 # v8.3.1
         env:
           VALIDATE_ALL_CODEBASE: ${{ inputs.full_scan || false }}
           # To report GitHub Actions status checks

--- a/diagtools/Dockerfile
+++ b/diagtools/Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1
+
+# Base image selection based on target OS
+ARG TARGETOS=linux
+FROM golang:1.25.4-bookworm@sha256:193dfb60e6979581389f7451d54a773434a37f167c54927fcaf11df4257599a4 AS builder-linux
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libc6-dev \
+    gcc-aarch64-linux-gnu \
+    libc6-dev-arm64-cross \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /workspace
+
+FROM golang:1.25.4-bookworm@sha256:193dfb60e6979581389f7451d54a773434a37f167c54927fcaf11df4257599a4 AS builder-windows
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc-mingw-w64-x86-64 \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /workspace
+
+# Select the appropriate builder based on TARGETOS
+FROM builder-${TARGETOS} AS builder
+WORKDIR /workspace
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum ./
+
+# Download dependencies with cache mount
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Copy source code
+COPY . .
+
+# Build with cache mounts
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+ARG BUILDARCH=amd64
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    if [ "${TARGETOS}" = "windows" ]; then \
+        CGO_ENABLED=1 GOOS=windows GOARCH=${TARGETARCH} CC=x86_64-w64-mingw32-gcc \
+        go build -ldflags '-linkmode external -extldflags "-static"' -o diagtools.exe .; \
+    else \
+        if [ "${BUILDARCH}" != "${TARGETARCH}" ]; then \
+            if [ "${TARGETARCH}" = "arm64" ]; then \
+                export CC=aarch64-linux-gnu-gcc; \
+            elif [ "${TARGETARCH}" = "amd64" ]; then \
+                export CC=x86_64-linux-gnu-gcc; \
+            fi; \
+        fi; \
+        CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+        go build -ldflags '-linkmode external -extldflags "-static"' -o diagtools .; \
+    fi
+
+# Export stage - just the binary in /out directory
+FROM scratch AS export
+COPY --from=builder /workspace/diagtools* /out/

--- a/diagtools/Makefile
+++ b/diagtools/Makefile
@@ -13,18 +13,73 @@ all: fmt vet build
 build:
 	@echo "Building $(BINARY_NAME)..."
 	@mkdir -p $(BUILD_DIR)
-	go build -o $(BUILD_DIR)/$(BINARY_NAME) .
+	CGO_ENABLED=1 go build -o $(BUILD_DIR)/$(BINARY_NAME) .
 
-# Build for multiple platforms
+# Build for multiple platforms (Linux, Windows, macOS)
 .PHONY: build-all
 build-all:
-	@echo "Building $(BINARY_NAME) for multiple platforms..."
+	@echo "Building $(BINARY_NAME) for all platforms..."
 	@mkdir -p $(BUILD_DIR)
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 .
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 .
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe .
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 .
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 .
+	@# Build Linux binaries using Docker (amd64 and arm64)
+	$(call build_platform,amd64,linux)
+	$(call build_platform,arm64,linux)
+	@# Build Windows binary using Docker (amd64)
+	$(call build_platform,amd64,windows)
+	@# Build macOS binaries only on macOS (requires CGO and native toolchain)
+	@if [ "$$(uname -s)" = "Darwin" ]; then \
+		echo "Building darwin-amd64 binary..."; \
+		CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 .; \
+		echo "Building darwin-arm64 binary..."; \
+		CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 .; \
+	else \
+		echo "Skipping darwin builds (not running on macOS)"; \
+	fi
+	@echo "All platform binaries built successfully:"
+	@ls -lh $(BUILD_DIR)/$(BINARY_NAME)-*
+
+# Internal helper to build for a specific platform using BuildKit
+# Args: $(1)=arch, $(2)=os (default: linux)
+define build_platform
+	@echo "Building $(2)-$(1) binary..."
+	@DOCKER_BUILDKIT=1 docker buildx build \
+		--target export \
+		--build-arg TARGETOS=$(2) \
+		--build-arg TARGETARCH=$(1) \
+		--output type=local,dest=$(BUILD_DIR)/tmp-$(2)-$(1) \
+		--load=false \
+		-f Dockerfile .
+	@if [ "$(2)" = "windows" ]; then \
+		mv $(BUILD_DIR)/tmp-$(2)-$(1)/out/diagtools.exe $(BUILD_DIR)/$(BINARY_NAME)-$(2)-$(1).exe; \
+	else \
+		mv $(BUILD_DIR)/tmp-$(2)-$(1)/out/diagtools $(BUILD_DIR)/$(BINARY_NAME)-$(2)-$(1); \
+	fi
+	@rm -rf $(BUILD_DIR)/tmp-$(2)-$(1)
+endef
+
+# Build Linux binaries using Docker with musl (works from any platform)
+.PHONY: build-linux-docker
+build-linux-docker:
+	@echo "Building $(BINARY_NAME) for Linux (amd64/arm64) with musl using Docker..."
+	@mkdir -p $(BUILD_DIR)
+	$(call build_platform,amd64,linux)
+	$(call build_platform,arm64,linux)
+	@echo "Linux binaries built successfully with musl (static linking)"
+
+# Build only Linux amd64 using Docker with musl (faster for development)
+.PHONY: build-linux-amd64-docker
+build-linux-amd64-docker:
+	@echo "Building $(BINARY_NAME) for Linux amd64 with musl using Docker..."
+	@mkdir -p $(BUILD_DIR)
+	$(call build_platform,amd64,linux)
+	@echo "Linux amd64 binary built successfully with musl (static linking)"
+
+# Build Windows amd64 binary using Docker (cross-compilation with MinGW)
+.PHONY: build-windows-docker
+build-windows-docker:
+	@echo "Building $(BINARY_NAME) for Windows amd64 using Docker..."
+	@mkdir -p $(BUILD_DIR)
+	$(call build_platform,amd64,windows)
+	@echo "Windows amd64 binary built successfully (static linking)"
 
 # Build for specific architecture (usage: make build-arch GOOS=linux GOARCH=amd64)
 .PHONY: build-arch
@@ -39,9 +94,9 @@ build-arch:
 		exit 1; \
 	fi
 	@if [ "$(GOOS)" = "windows" ]; then \
-		go build -o $(BUILD_DIR)/$(BINARY_NAME)-$(GOOS)-$(GOARCH).exe .; \
+		CGO_ENABLED=1 go build -o $(BUILD_DIR)/$(BINARY_NAME)-$(GOOS)-$(GOARCH).exe .; \
 	else \
-		go build -o $(BUILD_DIR)/$(BINARY_NAME)-$(GOOS)-$(GOARCH) .; \
+		CGO_ENABLED=1 go build -o $(BUILD_DIR)/$(BINARY_NAME)-$(GOOS)-$(GOARCH) .; \
 	fi
 
 # Clean build artifacts
@@ -104,16 +159,23 @@ run: build
 .PHONY: help
 help:
 	@echo "Available targets:"
-	@echo "  build        - Build the application"
-	@echo "  build-all    - Build for multiple platforms (Linux, Windows, macOS)"
-	@echo "  build-arch   - Build for specific architecture (GOOS=linux GOARCH=amd64)"
-	@echo "  clean        - Clean build artifacts"
-	@echo "  test         - Run tests"
-	@echo "  test-coverage- Run tests with coverage report"
-	@echo "  fmt          - Format code"
-	@echo "  vet          - Vet code for potential issues"
-	@echo "  lint         - Lint code (requires golangci-lint)"
-	@echo "  deps         - Download and tidy dependencies"
-	@echo "  install      - Install the binary to /usr/local/bin"
-	@echo "  run          - Build and run the application with --help"
-	@echo "  help         - Show this help message"
+	@echo "  build                       - Build the application for current platform"
+	@echo "  build-all                   - Build for all platforms (Linux, Windows, macOS)"
+	@echo ""
+	@echo "Docker builds (BuildKit with static linking):"
+	@echo "  build-linux-docker          - Build for Linux (amd64 & arm64) with musl (static)"
+	@echo "  build-linux-amd64-docker    - Build for Linux amd64 with musl (static, faster)"
+	@echo "  build-windows-docker        - Build for Windows amd64 with MinGW (static)"
+	@echo ""
+	@echo "Other targets:"
+	@echo "  build-arch                  - Build for specific architecture (GOOS=linux GOARCH=amd64)"
+	@echo "  clean                       - Clean build artifacts"
+	@echo "  test                        - Run tests"
+	@echo "  test-coverage               - Run tests with coverage report"
+	@echo "  fmt                         - Format code"
+	@echo "  vet                         - Vet code for potential issues"
+	@echo "  lint                        - Lint code (requires golangci-lint)"
+	@echo "  deps                        - Download and tidy dependencies"
+	@echo "  install                     - Install the binary to /usr/local/bin"
+	@echo "  run                         - Build and run the application with --help"
+	@echo "  help                        - Show this help message"

--- a/diagtools/actions/threaddump.go
+++ b/diagtools/actions/threaddump.go
@@ -2,10 +2,12 @@ package actions
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/Netcracker/qubership-profiler-agent/diagtools/constants"
 	"github.com/Netcracker/qubership-profiler-agent/diagtools/log"
+	"github.com/vlsi/jattach/v2"
 )
 
 type JavaThreadDumpAction struct {
@@ -13,19 +15,11 @@ type JavaThreadDumpAction struct {
 }
 
 func CreateThreadDumpAction(ctx context.Context) (action JavaThreadDumpAction, err error) {
-	longListing := constants.LongListeningArgs()
-	args := []string{"{{.Pid}}"}
-	if len(longListing) > 0 {
-		args = []string{longListing, "{{.Pid}}"}
-	}
-
 	action = JavaThreadDumpAction{
 		Action: Action{
 			DcdEnabled: constants.IsDcdEnabled(),
 			DumpPath:   constants.DumpFolder(),
 			PidName:    "java",
-			Command:    "jstack",
-			CmdArgs:    args,
 			CmdTimeout: 10 * time.Second,
 		},
 	}
@@ -48,17 +42,25 @@ func (action *JavaThreadDumpAction) GetThreadDump(ctx context.Context) (err erro
 		return
 	}
 
-	err = action.GetParams()
+	log.Infof(ctx, "collecting thread dump from JAVA_PID #%v to %s", action.Pid, action.DumpPath)
+
+	// Convert PID string to int for jattach
+	var pid int
+	pid, err = strconv.Atoi(action.Pid)
 	if err != nil {
+		log.Errorf(ctx, err, "failed to parse PID: %s", action.Pid)
 		return
 	}
 
-	log.Infof(ctx, "collecting thread dump from JAVA_PID #%v to %s", action.Pid, action.DumpPath)
-	var output []byte
-	output, err = action.RunJCmdWithOutput(ctx)
+	// Use jattach to get thread dump
+	var outputStr string
+	outputStr, err = jattach.GetThreadDump(pid)
 	if err != nil {
+		log.Errorf(ctx, err, "failed to get thread dump using jattach")
 		return
 	}
+
+	output := []byte(outputStr)
 	log.Infof(ctx, "thread dump taken, size in bytes: %d", len(output))
 
 	if action.DcdEnabled && len(output) > 0 {

--- a/diagtools/go.mod
+++ b/diagtools/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/consul/api v1.33.0
 	github.com/shirou/gopsutil/v4 v4.25.11
 	github.com/stretchr/testify v1.11.1
+	github.com/vlsi/jattach/v2 v2.2.1
 	golang.org/x/sys v0.38.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )

--- a/diagtools/go.sum
+++ b/diagtools/go.sum
@@ -17,8 +17,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ebitengine/purego v0.9.0 h1:mh0zpKBIXDceC63hpvPuGLiJ8ZAa3DfrFTudmfi8A4k=
-github.com/ebitengine/purego v0.9.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/ebitengine/purego v0.9.1 h1:a/k2f2HQU3Pi399RPW1MOaZyhKJL9w/xFpKAg4q1s0A=
 github.com/ebitengine/purego v0.9.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
@@ -165,8 +163,6 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/shirou/gopsutil/v4 v4.25.10 h1:at8lk/5T1OgtuCp+AwrDofFRjnvosn0nkN2OLQ6g8tA=
-github.com/shirou/gopsutil/v4 v4.25.10/go.mod h1:+kSwyC8DRUD9XXEHCAFjK+0nuArFJM0lva+StQAcskM=
 github.com/shirou/gopsutil/v4 v4.25.11 h1:X53gB7muL9Gnwwo2evPSE+SfOrltMoR6V3xJAXZILTY=
 github.com/shirou/gopsutil/v4 v4.25.11/go.mod h1:EivAfP5x2EhLp2ovdpKSozecVXn1TmuG7SMzs/Wh4PU=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -182,15 +178,13 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tklauser/go-sysconf v0.3.15 h1:VE89k0criAymJ/Os65CSn1IXaol+1wrsFHEB8Ol49K4=
-github.com/tklauser/go-sysconf v0.3.15/go.mod h1:Dmjwr6tYFIseJw7a3dRLJfsHAMXZ3nEnL/aZY+0IuI4=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
-github.com/tklauser/numcpus v0.10.0 h1:18njr6LDBk1zuna922MgdjQuJFjrdppsZG60sHGfjso=
-github.com/tklauser/numcpus v0.10.0/go.mod h1:BiTKazU708GQTYF4mB+cmlpT2Is1gLk7XVuEeem8LsQ=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/vlsi/jattach/v2 v2.2.1 h1:kWfr/q8bW3vSCSsG68djc9efaxLr0SrRUPct/CsRH7Q=
+github.com/vlsi/jattach/v2 v2.2.1/go.mod h1:yejpkylFwqaKaYe8LLvAy/UxzVHN4hZTJFSralpNVB0=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/installer/src/test/java/com/netcracker/profiler/test/agent/JavaBaseImageTest.java
+++ b/installer/src/test/java/com/netcracker/profiler/test/agent/JavaBaseImageTest.java
@@ -32,6 +32,20 @@ public class JavaBaseImageTest {
                     "system property qubership.profiler.java-base-image.tag");
 
     @Test
+    void diagtoolsExecutesSuccessfully() {
+        try (GenericContainer<?> container = new GenericContainer<>(CORE_BASE_IMAGE_TAG)
+                .withCommand("/app/diag/diagtools", "scan")
+                .withStartupAttempts(1)
+                .withStartupTimeout(Duration.ofSeconds(30))
+                .withLogConsumer(new LogToConsolePrinter("[diagtools-test] "))
+                .withStartupCheckStrategy(new OneShotStartupCheckStrategy())) {
+            container.start();
+        } catch (Exception e) {
+            fail("Failed to execute diagtools in container: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
     void profilerSendsDataToMockCollector() {
         try (MockCollectorServer mockCollector =
                      new MockCollectorServer(0, ProtocolConst.PLAIN_SOCKET_BACKLOG)


### PR DESCRIPTION
This removes dependency on jstack and jmap binaries

Fixes https://github.com/Netcracker/qubership-profiler-agent/issues/424