### PR TITLE
chore: use tag names for github actions rather than branch names

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,16 +44,16 @@ jobs:
           java-version: 21
           server-id: central
       - name: Setup Go 1.25
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: '1.25.6'
       - name: Test
-        uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca # v3
+        uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca # v3.0.1
         with:
           multi-cache-enabled: false
           arguments: --scan --no-parallel build
       - name: Publish snapshots
-        uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca # v3
+        uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca # v3.0.1
         if: ${{ env.CENTRAL_PORTAL_USERNAME != '' }}
         with:
           arguments: publishAllPublicationsToCentralSnapshotsRepository

--- a/.github/workflows/gradle-dependency-submit.yaml
+++ b/.github/workflows/gradle-dependency-submit.yaml
@@ -28,7 +28,7 @@ jobs:
         java-version: 21
         server-id: central
     - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
+      uses: gradle/actions/dependency-submission@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
       with:
         # Profiler plugins do not expose the dependencies to the runtime, so the versions used for the build
         # do not affect the execution. At the same time, we might need to build plugins for different thirdparty

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Restore lychee cache
-        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
         id: restore-cache
         with:
           path: .lycheecache
@@ -32,7 +32,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2
+        uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
         with:
           args: >-
             './**/*.md'

--- a/.github/workflows/pr-lint-title.yaml
+++ b/.github/workflows/pr-lint-title.yaml
@@ -16,6 +16,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get the current version
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: current_version
         with:
           # language=javascript
@@ -39,7 +39,7 @@ jobs:
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Update release body draft
-        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         id: prepare_release
         with:
           disable-autolabeler: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Check if tag exists
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           VERSION: ${{ steps.release_version.outputs.version }}
         with:
@@ -109,7 +109,7 @@ jobs:
       # Publish to Central before generating a tag, so we don't need to drop the tag if
       # Central deployment fails.
       - name: Publish to Central Portal
-        uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca # v3
+        uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca # v3.0.1
         with:
           arguments: publishAggregationToCentralPortal
           # language=properties
@@ -123,7 +123,7 @@ jobs:
           SIGNING_PGP_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       - name: Publish GitHub release
-        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         id: publish_release
         with:
           disable-autolabeler: true

--- a/renovate.json
+++ b/renovate.json
@@ -19,13 +19,16 @@
       "groupName": "Go",
       "matchDatasources": [
         "docker",
+        "github-actions",
+        "github-releases",
         "golang-version",
-        "github-releases"
+        "gomod"
       ],
       "matchPackageNames": [
         "go",
         "golang",
-        "actions/go-versions"
+        "actions/go-versions",
+        "actions/setup-go"
       ]
     },
     {


### PR DESCRIPTION
It makes "bump version" reviews easier to understand
