### PR TITLE
fix: skip loading plugin jars if multiple jar files include a plugin with the same id

### DIFF
--- a/boot/src/test/java/com/netcracker/profiler/agent/BootstrapTest.java
+++ b/boot/src/test/java/com/netcracker/profiler/agent/BootstrapTest.java
@@ -1,0 +1,65 @@
+package com.netcracker.profiler.agent;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.jar.Attributes;
+
+public class BootstrapTest {
+    @Test
+    void extractPluginId_fromExplicitAttribute() {
+        Attributes attrs = new Attributes();
+        attrs.putValue("Plugin-Id", "spring");
+        assertEquals(Collections.singletonList("spring"), Bootstrap.extractPluginId(attrs));
+    }
+
+    @Test
+    void extractPluginId_fromEntryPoints() {
+        Attributes attrs = new Attributes();
+        attrs.putValue("Entry-Points", "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_spring");
+        assertEquals(Collections.singletonList("spring"), Bootstrap.extractPluginId(attrs));
+    }
+
+    @Test
+    void extractPluginId_preferExplicitOverEntryPoints() {
+        Attributes attrs = new Attributes();
+        attrs.putValue("Plugin-Id", "explicit-id");
+        attrs.putValue("Entry-Points", "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_fallback");
+        assertEquals(Collections.singletonList("explicit-id"), Bootstrap.extractPluginId(attrs));
+    }
+
+    @Test
+    void extractPluginId_multipleEntryPoints() {
+        Attributes attrs = new Attributes();
+        attrs.putValue("Entry-Points", "com.example.Other com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_jdbc");
+        assertEquals(Collections.singletonList("jdbc"), Bootstrap.extractPluginId(attrs));
+    }
+
+    @Test
+    void extractPluginId_multipleEntryPoints2() {
+        Attributes attrs = new Attributes();
+        attrs.putValue("Entry-Points", "com.example.Other com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_jdbc com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_spring");
+        assertEquals(Arrays.asList("jdbc", "spring"), Bootstrap.extractPluginId(attrs));
+    }
+
+    @Test
+    void extractPluginId_noPluginId() {
+        Attributes attrs = new Attributes();
+        attrs.putValue("Entry-Points", "com.example.SomeOtherClass");
+        assertEquals(Collections.emptyList(), Bootstrap.extractPluginId(attrs));
+    }
+
+    @Test
+    void extractPluginId_nullAttributes() {
+        assertEquals(Collections.emptyList(), Bootstrap.extractPluginId(null));
+    }
+
+    @Test
+    void extractPluginId_emptyAttributes() {
+        Attributes attrs = new Attributes();
+        assertEquals(Collections.emptyList(), Bootstrap.extractPluginId(attrs));
+    }
+}

--- a/build-logic/jvm/src/main/kotlin/build-logic.profiler-plugin.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.profiler-plugin.gradle.kts
@@ -7,6 +7,7 @@ tasks.jar {
     manifest {
         attributes["Entry-Points"] = "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_${project.name}"
         attributes["Esc-Dependencies"] = "instrumenter"
+        attributes["Plugin-Id"] = project.name
     }
 }
 

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
 tasks.shadowJar {
     manifest {
         attributes["Entry-Points"] = "com.netcracker.profiler.agent.plugins.EnhancerRegistryPluginImpl com.netcracker.profiler.agent.plugins.ProfilerTransformerPluginImpl com.netcracker.profiler.agent.plugins.DumperPluginImpl"
+        attributes["Plugin-Id"] = "profiler-runtime"
     }
 }


### PR DESCRIPTION
### Describe Your Changes

It should fix the following error, and it should just skip loading a plugin if there are multiple jar files including the same plugin id.

```
Caused by: java.lang.ClassCastException: class com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_activemq cannot be cast to class com.netcracker.profiler.instrument.enhancement.EnhancerPlugin (com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_activemq is in unnamed module of loader com.netcracker.profiler.agent.PluginClassLoader @11cfb8b; com.netcracker.profiler.instrument.enhancement.EnhancerPlugin is in unnamed module of loader com.netcracker.profiler.agent.PluginClassLoader @102b3b1)
	at com.netcracker.profiler.configuration.ConfigurationImpl.parseEnhancer(ConfigurationImpl.java:596)
	at com.netcracker.profiler.configuration.ConfigurationImpl.parseFile(ConfigurationImpl.java:203)
	... 33 more
```
