### PR TITLE
feat: make DIAGNOSTIC_UPLOAD_TIMEOUT configurable

### DIFF
--- a/diagtools/constants/helpers.go
+++ b/diagtools/constants/helpers.go
@@ -371,3 +371,19 @@ func parseDurationOrSeconds(interval string) (time.Duration, error) {
 
 	return 0, err
 }
+
+// UploadTimeout returns the HTTP client timeout for sending dump files (e.g. to dumps-collector).
+// Configured via DIAGNOSTIC_UPLOAD_TIMEOUT; supports duration strings (e.g. "30m", "1h") or seconds as integer.
+// Default is 5 minutes.
+func UploadTimeout(ctx context.Context) time.Duration {
+	env := os.Getenv(NcDiagUploadTimeout)
+	if env == "" {
+		return 5 * time.Minute
+	}
+	d, err := parseDurationOrSeconds(env)
+	if err != nil {
+		log.Error(ctx, err, "Parsing upload timeout failed. Will use default: 5m")
+		return 5 * time.Minute
+	}
+	return d
+}

--- a/diagtools/constants/helpers_test.go
+++ b/diagtools/constants/helpers_test.go
@@ -434,3 +434,28 @@ func TestGetLogLevelFromEnv(t *testing.T) {
 	os.Setenv("LOG_LEVEL", "TRACE")
 	assert.Equal(t, "info", GetLogLevelFromEnv())
 }
+
+func TestUploadTimeout(t *testing.T) {
+	os.Setenv("DIAGNOSTIC_UPLOAD_TIMEOUT", "")
+	assert.Equal(t, 5*time.Minute, UploadTimeout(testCtx)) // default timeout
+
+	os.Setenv("DIAGNOSTIC_UPLOAD_TIMEOUT", "600")
+	assert.Equal(t, 600*time.Second, UploadTimeout(testCtx)) // integer value means seconds
+
+	os.Setenv("DIAGNOSTIC_UPLOAD_TIMEOUT", "10s")
+	assert.Equal(t, 10*time.Second, UploadTimeout(testCtx))
+
+	os.Setenv("DIAGNOSTIC_UPLOAD_TIMEOUT", "30m")
+	assert.Equal(t, 30*time.Minute, UploadTimeout(testCtx))
+
+	os.Setenv("DIAGNOSTIC_UPLOAD_TIMEOUT", "1h")
+	assert.Equal(t, 1*time.Hour, UploadTimeout(testCtx))
+
+	os.Setenv("DIAGNOSTIC_UPLOAD_TIMEOUT", "bad")
+	assert.Equal(t, 5*time.Minute, UploadTimeout(testCtx)) // default timeout for invalid values
+
+	os.Setenv(NcDiagUploadTimeout, "15m")
+	assert.Equal(t, 15*time.Minute, UploadTimeout(testCtx))
+	assert.Equal(t, "DIAGNOSTIC_UPLOAD_TIMEOUT", NcDiagUploadTimeout)
+	os.Setenv("DIAGNOSTIC_UPLOAD_TIMEOUT", "")
+}

--- a/diagtools/constants/names.go
+++ b/diagtools/constants/names.go
@@ -28,6 +28,7 @@ const (
 	NcDiagCenterDumpEnabled = "DIAGNOSTIC_CENTER_DUMPS_ENABLED"             // heap dump collection after OOM                     // ENABLED by default
 	NcDiagDumpInterval      = "DIAGNOSTIC_DUMP_INTERVAL"
 	NcDiagScanInterval      = "DIAGNOSTIC_SCAN_INTERVAL"
+	NcDiagUploadTimeout     = "DIAGNOSTIC_UPLOAD_TIMEOUT" // HTTP client timeout for sending dump files (default 5m)
 	NcProfilerFolder        = "PROFILER_FOLDER"
 	ZipCompressionLevel     = "NC_HEAP_DUMP_COMPRESSION_LEVEL"
 	NcCloudNamespace        = "CLOUD_NAMESPACE"

--- a/diagtools/utils/sender.go
+++ b/diagtools/utils/sender.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/Netcracker/qubership-profiler-agent/diagtools/constants"
 	"github.com/Netcracker/qubership-profiler-agent/diagtools/log"
 )
 
@@ -276,6 +277,6 @@ func FileClient(ctx context.Context) (*http.Client, error) {
 		log.Error(ctx, err, "err While creating http client with TLS configuration")
 		return nil, err
 	}
-	client.Timeout = time.Minute * 5
+	client.Timeout = constants.UploadTimeout(ctx)
 	return client, nil
 }


### PR DESCRIPTION
### Describe Your Changes

Currently, we have noticed, at https://github.com/Netcracker/qubership-profiler-agent/blob/e0d5fbd4c49da02771b34ae462d390d2ffdfdd3f/diagtools/utils/sender.go#L279, client timeout is hardcoded as 5 mins.  Due to this, while sending large dumps, we were getting timeout after 5 mins. So, we have introduced DIAGNOSTIC_UPLOAD_TIMEOUT param, so that, we can configure higher timeout value.

### Checklist

The following checks are **mandatory**:

* [Y] My change adheres [Qubership contributing guidelines](/CONTRIBUTING.md).
