### PR TITLE
feat(diagtools): upload thread dumps without local files

### DIFF
--- a/diagtools/actions/threaddump.go
+++ b/diagtools/actions/threaddump.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"context"
-	"os"
 	"strconv"
 	"time"
 
@@ -64,17 +63,15 @@ func (action *JavaThreadDumpAction) GetThreadDump(ctx context.Context) (err erro
 	output := []byte(outputStr)
 	log.Infof(ctx, "thread dump taken, size in bytes: %d", len(output))
 
-	err = os.WriteFile(action.DumpPath, output, 0644)
+	if len(output) == 0 {
+		return nil
+	}
+
+	err = action.GetTargetUrl(ctx)
 	if err != nil {
-		log.Errorf(ctx, err, "failed to write thread dump to %s", action.DumpPath)
 		return
 	}
 
-	if action.DcdEnabled && len(output) > 0 {
-		err = action.GetTargetUrl(ctx)
-		if err == nil {
-			err = action.UploadOutputToDiagnosticCenter(ctx, output)
-		}
-	}
+	err = action.UploadOutputToDiagnosticCenter(ctx, output)
 	return
 }

--- a/diagtools/src/test/kotlin/org/qubership/profiler/diagtools/ThreadDumpTest.kt
+++ b/diagtools/src/test/kotlin/org/qubership/profiler/diagtools/ThreadDumpTest.kt
@@ -17,7 +17,9 @@ class ThreadDumpTest {
 
         GenericContainer("eclipse-temurin:21-jdk")
             .withLogConsumer(LogToConsolePrinter("[diagtools] "))
-            .withEnv("DIAGNOSTIC_CENTER_DUMPS_ENABLED", "false")
+            .withEnv("DIAGNOSTIC_CENTER_DUMPS_ENABLED", "true")
+            .withEnv("NC_DIAGNOSTIC_AGENT_SERVICE", "http://127.0.0.1:18080")
+            .withEnv("NAMESPACE", "test-namespace")
             .withEnv("LOG_TO_CONSOLE", "true")
             .withStartupCheckStrategy(
                 OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(30))
@@ -31,6 +33,31 @@ class ThreadDumpTest {
                 // language=bash
                 """
                 mkdir -p /tmp/diagnostic/log /app/ncdiag
+                cat > /tmp/UploadServer.java << 'JAVA'
+                import com.sun.net.httpserver.HttpExchange;
+                import com.sun.net.httpserver.HttpServer;
+                import java.io.IOException;
+                import java.net.InetSocketAddress;
+                import java.nio.charset.StandardCharsets;
+
+                public class UploadServer {
+                    public static void main(String[] args) throws Exception {
+                        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 18080), 0);
+                        server.createContext("/", UploadServer::handle);
+                        server.start();
+                    }
+
+                    private static void handle(HttpExchange exchange) throws IOException {
+                        byte[] body = exchange.getRequestBody().readAllBytes();
+                        System.out.println("===UPLOAD_BODY_START===");
+                        System.out.print(new String(body, StandardCharsets.UTF_8));
+                        System.out.println();
+                        System.out.println("===UPLOAD_BODY_END===");
+                        exchange.sendResponseHeaders(200, -1);
+                        exchange.close();
+                    }
+                }
+                JAVA
                 cat > /tmp/Sleep.java << 'JAVA'
                 public class Sleep {
                     public static void main(String[] args) throws Exception {
@@ -38,13 +65,17 @@ class ThreadDumpTest {
                     }
                 }
                 JAVA
+                javac /tmp/UploadServer.java -d /tmp
                 javac /tmp/Sleep.java -d /tmp
+                java -cp /tmp UploadServer &
                 java -cp /tmp Sleep &
                 sleep 3
                 diagtools dump
-                echo '===FILE_CONTENT_START==='
-                cat /tmp/diagnostic/*.td.txt
-                echo '===FILE_CONTENT_END==='
+                if ls /tmp/diagnostic/*.td.txt >/dev/null 2>&1; then
+                    echo '===LOCAL_FILE_EXISTS==='
+                else
+                    echo '===LOCAL_FILE_MISSING==='
+                fi
                 """.trimIndent()
             )
             .use { container ->
@@ -52,19 +83,22 @@ class ThreadDumpTest {
 
                 val logs = container.logs
                 val fileContent =
-                    logs.substringAfter("===FILE_CONTENT_START===").substringBefore("===FILE_CONTENT_END===")
-                assertTrue(fileContent.contains("\"main\"")) {
+                    logs.substringAfter("===UPLOAD_BODY_START===").substringBefore("===UPLOAD_BODY_END===")
+                assertTrue(fileContent.contains("Full thread dump")) {
                     """
-                    Thread dump file should contain the "main" thread.
-                    File content:
+                    Uploaded payload should contain a valid thread dump.
+                    Upload content:
                     $fileContent
                     """.trimIndent()
                 }
-                assertTrue(fileContent.contains("java.lang.Thread.sleep")) {
+                assertTrue(fileContent.contains("JVM response code = 0")) {
                     """
-                    Thread dump file should contain java.lang.Thread.sleep.
-                    File content: $fileContent
+                    Uploaded payload should contain successful jattach output.
+                    Upload content: $fileContent
                     """.trimIndent()
+                }
+                assertTrue(logs.contains("===LOCAL_FILE_MISSING===")) {
+                    "Thread dump file should not be created locally. Container logs:\n$logs"
                 }
             }
     }


### PR DESCRIPTION
There's no need to save thread dump as a file as we can just send it directly to the collector