### PR TITLE
chore(ci): auto-update Go version to build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: diagtools/go.mod
+          check-latest: true
       - name: Test
         uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca # v3.0.1
         with:


### PR DESCRIPTION
### Describe Your Changes

Add a parameter to check the latest Go version and use the latest to build if it is available.

The minimal version will be detected from `go.mod`, and the action will check the latest available Go version.
> It supports major (e.g., "1") and major.minor (e.g., "1.25") version selectors, always resolving to the latest matching patch release.

Documentation:
https://github.com/actions/setup-go/blob/main/docs/advanced-usage.md#check-latest-version

### Checklist

The following checks are **mandatory**:

* [x] My change adheres [Qubership contributing guidelines](/CONTRIBUTING.md).
