### PR TITLE
chore: remove @Inject from AbstractSecurityFilter (fixes errorprone warnings)

### DIFF
--- a/web/src/main/java/com/netcracker/profiler/security/AbstractSecurityFilter.java
+++ b/web/src/main/java/com/netcracker/profiler/security/AbstractSecurityFilter.java
@@ -2,7 +2,6 @@ package com.netcracker.profiler.security;
 
 import java.io.IOException;
 
-import jakarta.inject.Inject;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
@@ -16,8 +15,7 @@ public abstract class AbstractSecurityFilter implements Filter {
 
     protected final DummySecurityService securityService;
 
-    @Inject
-    public AbstractSecurityFilter(DummySecurityService securityService) {
+    protected AbstractSecurityFilter(DummySecurityService securityService) {
         this.securityService = securityService;
     }
 


### PR DESCRIPTION
AbstractSecurityFilter is abstract, so it will never be constructed explicitly, so there's no need in `@Inject`.
