### PR TITLE
feat(diagtools): bound disk usage of pending dumps with age + size retention

### DIFF
--- a/backend/docs/add-cdt-agent.md
+++ b/backend/docs/add-cdt-agent.md
@@ -200,6 +200,8 @@ Environment variables that allow you to configure the behavior of bash scripts:
 | NC_DIAGNOSTIC_LOGS_FOLDER        | /tmp/diagnostic     | no        | Allow to specify directory which will use to save                                                                                  |
 | CDT_LOG_LEVEL                    | `WARN`              | no        | Allow to specify log level for cdt-agent (`DEBUG`, `INFO`, `WARN` (default), `ERROR`, `OFF`) and for bash scripts (no log / debug) |
 | DIAGNOSTIC_DUMP_INTERVAL         | 60                  | no        | Allow to specify interval which will use to make thread dump and collect TOP                                                       |
+| DIAGNOSTIC_UPLOAD_MAX_AGE        | 48h                 | no        | Pending heap dump / core / hs_err files (`*.hprof*` in `NC_DIAGNOSTIC_LOGS_FOLDER`) older than this are deleted on each scan tick. Accepts Go duration syntax (e.g. `48h`, `30m`). |
+| DIAGNOSTIC_PENDING_MAX_BYTES     | 10Gi                | no        | Safety net against disk buildup: if combined size of pending `*.hprof*` exceeds this, oldest files are deleted (by mtime) until total is at or below the limit, always keeping at least the newest file. Accepts K/M/G/T (×1000) or Ki/Mi/Gi/Ti (×1024) suffixes; bare integer = bytes. |
 <!-- markdownlint-enable line-length -->
 
 Environment variables that can be used to configure the CDT agent when the cloud core image is not

--- a/diagtools/actions/cleanup.go
+++ b/diagtools/actions/cleanup.go
@@ -1,0 +1,130 @@
+package actions
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/Netcracker/qubership-profiler-agent/diagtools/log"
+)
+
+// CleanupResult summarizes how many files the cleanup removed and how many bytes were freed.
+type CleanupResult struct {
+	RemovedByAge   int
+	RemovedByQuota int
+	FreedBytes     int64
+}
+
+// CleanupStaleDumps enforces retention on pending dump artifacts:
+//
+//  1. Files whose mtime is older than maxAge are deleted, including the single
+//     newest file. The age rule is absolute: "after maxAge, the file is gone".
+//  2. Of what remains, if the combined size exceeds maxBytes, the oldest files
+//     (by mtime) are deleted in order until the total is at or below the limit.
+//     The newest remaining file is always kept, even if it alone exceeds maxBytes.
+//
+// Each deletion is logged at WARN level with filename, size, age, and reason.
+// A value of 0 for maxAge or maxBytes disables that step.
+func CleanupStaleDumps(
+	ctx context.Context,
+	patterns []string,
+	maxAge time.Duration,
+	maxBytes int64,
+) CleanupResult {
+	var result CleanupResult
+
+	files := collectFiles(ctx, patterns)
+	if len(files) == 0 {
+		return result
+	}
+
+	now := time.Now()
+
+	if maxAge > 0 {
+		kept := files[:0]
+		for _, f := range files {
+			age := now.Sub(f.info.ModTime())
+			if age > maxAge {
+				if removeOne(ctx, f, age, "max_age_exceeded") {
+					result.RemovedByAge++
+					result.FreedBytes += f.info.Size()
+				}
+				continue
+			}
+			kept = append(kept, f)
+		}
+		files = kept
+	}
+
+	if maxBytes > 0 && len(files) > 1 {
+		// Sort oldest first so we evict from the front until the newest remains.
+		sort.SliceStable(files, func(i, j int) bool {
+			return files[i].info.ModTime().Before(files[j].info.ModTime())
+		})
+		var total int64
+		for _, f := range files {
+			total += f.info.Size()
+		}
+		i := 0
+		for total > maxBytes && len(files)-i > 1 {
+			f := files[i]
+			age := now.Sub(f.info.ModTime())
+			if removeOne(ctx, f, age, "pending_quota_exceeded") {
+				result.RemovedByQuota++
+				result.FreedBytes += f.info.Size()
+				total -= f.info.Size()
+			}
+			i++
+		}
+	}
+
+	return result
+}
+
+type pendingFile struct {
+	path string
+	info os.FileInfo
+}
+
+// collectFiles expands glob patterns, stats each match, and returns
+// unique regular files. Duplicates across overlapping patterns are dropped.
+func collectFiles(ctx context.Context, patterns []string) []pendingFile {
+	seen := make(map[string]struct{})
+	var out []pendingFile
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Clean(pattern))
+		if err != nil {
+			log.Errorf(ctx, err, "failed to glob pattern %q for cleanup", pattern)
+			continue
+		}
+		for _, m := range matches {
+			if _, dup := seen[m]; dup {
+				continue
+			}
+			info, err := os.Stat(m)
+			if err != nil {
+				log.Errorf(ctx, err, "failed to stat %s during cleanup", m)
+				continue
+			}
+			if !info.Mode().IsRegular() {
+				continue
+			}
+			seen[m] = struct{}{}
+			out = append(out, pendingFile{path: m, info: info})
+		}
+	}
+	return out
+}
+
+func removeOne(ctx context.Context, f pendingFile, age time.Duration, reason string) bool {
+	log.Warnf(ctx,
+		"deleting stale dump file: %s (size=%d bytes, age=%s, reason=%s)",
+		f.path, f.info.Size(), age.Truncate(time.Second), reason)
+	if err := os.Remove(f.path); err != nil {
+		log.Errorf(ctx, err, "failed to delete stale dump file %s", f.path)
+		return false
+	}
+	return true
+}

--- a/diagtools/actions/cleanup_test.go
+++ b/diagtools/actions/cleanup_test.go
@@ -1,0 +1,164 @@
+package actions
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFileWithSizeAndAge creates a file with exactly `size` bytes and sets its
+// mtime to `now - age`. Returns the full path.
+func writeFileWithSizeAndAge(t *testing.T, dir, name string, size int64, age time.Duration) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	content := make([]byte, size)
+	require.NoError(t, os.WriteFile(path, content, 0644))
+	when := time.Now().Add(-age)
+	require.NoError(t, os.Chtimes(path, when, when))
+	return path
+}
+
+func listRemaining(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestCleanup_EmptyFolder(t *testing.T) {
+	dir := t.TempDir()
+	pattern := filepath.Join(dir, "*.hprof*")
+
+	res := CleanupStaleDumps(testCtx, []string{pattern}, 48*time.Hour, 10<<30)
+
+	assert.Equal(t, CleanupResult{}, res)
+}
+
+func TestCleanup_FreshBelowQuota(t *testing.T) {
+	dir := t.TempDir()
+	writeFileWithSizeAndAge(t, dir, "a.hprof", 100, time.Hour)
+	writeFileWithSizeAndAge(t, dir, "b.hprof", 100, 2*time.Hour)
+
+	pattern := filepath.Join(dir, "*.hprof*")
+	res := CleanupStaleDumps(testCtx, []string{pattern}, 48*time.Hour, 10<<30)
+
+	assert.Equal(t, 0, res.RemovedByAge)
+	assert.Equal(t, 0, res.RemovedByQuota)
+	assert.Equal(t, []string{"a.hprof", "b.hprof"}, listRemaining(t, dir))
+}
+
+func TestCleanup_SingleTooOld_IsDeleted(t *testing.T) {
+	// Age rule must apply even to the newest (single) file — "after maxAge, it's gone".
+	dir := t.TempDir()
+	writeFileWithSizeAndAge(t, dir, "old.hprof", 100, 72*time.Hour)
+
+	pattern := filepath.Join(dir, "*.hprof*")
+	res := CleanupStaleDumps(testCtx, []string{pattern}, 48*time.Hour, 10<<30)
+
+	assert.Equal(t, 1, res.RemovedByAge)
+	assert.Equal(t, int64(100), res.FreedBytes)
+	assert.Empty(t, listRemaining(t, dir))
+}
+
+func TestCleanup_MixedAges(t *testing.T) {
+	dir := t.TempDir()
+	writeFileWithSizeAndAge(t, dir, "fresh.hprof", 100, time.Hour)
+	writeFileWithSizeAndAge(t, dir, "stale.hprof", 200, 72*time.Hour)
+
+	pattern := filepath.Join(dir, "*.hprof*")
+	res := CleanupStaleDumps(testCtx, []string{pattern}, 48*time.Hour, 10<<30)
+
+	assert.Equal(t, 1, res.RemovedByAge)
+	assert.Equal(t, int64(200), res.FreedBytes)
+	assert.Equal(t, []string{"fresh.hprof"}, listRemaining(t, dir))
+}
+
+func TestCleanup_OverQuota_KeepsNewest(t *testing.T) {
+	// Quota rule must never delete the single newest file, even if it alone exceeds the cap.
+	dir := t.TempDir()
+	writeFileWithSizeAndAge(t, dir, "a.hprof", 1000, 3*time.Hour)
+	writeFileWithSizeAndAge(t, dir, "b.hprof", 1000, 2*time.Hour)
+	writeFileWithSizeAndAge(t, dir, "c.hprof", 5000, time.Hour) // newest
+
+	pattern := filepath.Join(dir, "*.hprof*")
+	// Quota 100 bytes — everything except newest should go.
+	res := CleanupStaleDumps(testCtx, []string{pattern}, 0, 100)
+
+	assert.Equal(t, 0, res.RemovedByAge)
+	assert.Equal(t, 2, res.RemovedByQuota)
+	assert.Equal(t, int64(2000), res.FreedBytes)
+	assert.Equal(t, []string{"c.hprof"}, listRemaining(t, dir))
+}
+
+func TestCleanup_OverQuota_LRUUntilUnderLimit(t *testing.T) {
+	// Evict oldest first until total <= quota.
+	dir := t.TempDir()
+	writeFileWithSizeAndAge(t, dir, "a.hprof", 300, 4*time.Hour) // oldest
+	writeFileWithSizeAndAge(t, dir, "b.hprof", 300, 3*time.Hour)
+	writeFileWithSizeAndAge(t, dir, "c.hprof", 300, 2*time.Hour)
+	writeFileWithSizeAndAge(t, dir, "d.hprof", 300, time.Hour) // newest
+
+	pattern := filepath.Join(dir, "*.hprof*")
+	// Total = 1200, quota = 700. Need to evict 500 bytes: "a" (300) then "b" (300) → 600 left, done.
+	res := CleanupStaleDumps(testCtx, []string{pattern}, 0, 700)
+
+	assert.Equal(t, 2, res.RemovedByQuota)
+	assert.Equal(t, int64(600), res.FreedBytes)
+	assert.Equal(t, []string{"c.hprof", "d.hprof"}, listRemaining(t, dir))
+}
+
+func TestCleanup_AgeThenSizeComposition(t *testing.T) {
+	// Age runs first, then size.
+	dir := t.TempDir()
+	writeFileWithSizeAndAge(t, dir, "ancient.hprof", 500, 72*time.Hour) // killed by age
+	writeFileWithSizeAndAge(t, dir, "old.hprof", 400, 5*time.Hour)      // killed by quota
+	writeFileWithSizeAndAge(t, dir, "mid.hprof", 400, 3*time.Hour)      // survives
+	writeFileWithSizeAndAge(t, dir, "new.hprof", 400, time.Hour)        // newest, survives
+
+	pattern := filepath.Join(dir, "*.hprof*")
+	res := CleanupStaleDumps(testCtx, []string{pattern}, 48*time.Hour, 1000)
+
+	assert.Equal(t, 1, res.RemovedByAge)
+	assert.Equal(t, 1, res.RemovedByQuota)
+	assert.Equal(t, int64(900), res.FreedBytes)
+	assert.Equal(t, []string{"mid.hprof", "new.hprof"}, listRemaining(t, dir))
+}
+
+func TestCleanup_HprofAndZip_CountedIndependently(t *testing.T) {
+	// A .hprof and its matching .hprof.zip are independent files with their own mtime/size.
+	// The zip is typically younger (created later from the raw dump).
+	dir := t.TempDir()
+	writeFileWithSizeAndAge(t, dir, "20260101T000000.hprof", 1_000_000, 10*time.Minute)
+	writeFileWithSizeAndAge(t, dir, "20260101T000000.hprof.zip", 50_000, time.Minute)
+
+	pattern := filepath.Join(dir, "*.hprof*")
+	// Quota 100_000 — the raw .hprof (older, larger) must be dropped; the zip stays.
+	res := CleanupStaleDumps(testCtx, []string{pattern}, 0, 100_000)
+
+	assert.Equal(t, 1, res.RemovedByQuota)
+	assert.Equal(t, int64(1_000_000), res.FreedBytes)
+	assert.Equal(t, []string{"20260101T000000.hprof.zip"}, listRemaining(t, dir))
+}
+
+func TestCleanup_DisabledByZero(t *testing.T) {
+	// maxAge=0 and maxBytes=0 disable their respective checks.
+	dir := t.TempDir()
+	writeFileWithSizeAndAge(t, dir, "ancient.hprof", 500, 365*24*time.Hour)
+	writeFileWithSizeAndAge(t, dir, "huge.hprof", 1<<30, time.Minute)
+
+	pattern := filepath.Join(dir, "*.hprof*")
+	res := CleanupStaleDumps(testCtx, []string{pattern}, 0, 0)
+
+	assert.Equal(t, CleanupResult{}, res)
+	assert.Equal(t, []string{"ancient.hprof", "huge.hprof"}, listRemaining(t, dir))
+}

--- a/diagtools/constants/constants.go
+++ b/diagtools/constants/constants.go
@@ -1,6 +1,9 @@
 package constants
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"time"
+)
 
 // datetime formats
 const (
@@ -15,6 +18,9 @@ const (
 	DefaultNumberOfLogFileBackups  = 5
 	DefaultNcDiagDumpInterval      = "1m"
 	DefaultNcDiagScanInterval      = "1m"
+
+	DefaultDiagnosticUploadMaxAge    = 48 * time.Hour
+	DefaultDiagnosticPendingMaxBytes = int64(10 * 1024 * 1024 * 1024) // 10 GiB
 )
 
 // default external services

--- a/diagtools/constants/helpers.go
+++ b/diagtools/constants/helpers.go
@@ -387,3 +387,79 @@ func UploadTimeout(ctx context.Context) time.Duration {
 	}
 	return d
 }
+
+// UploadMaxAge returns how long a pending dump file is allowed to sit on disk
+// before the scheduled cleanup removes it. Configured via DIAGNOSTIC_UPLOAD_MAX_AGE
+// using Go duration syntax (e.g. "48h", "30m"). Default is 48 hours.
+func UploadMaxAge(ctx context.Context) time.Duration {
+	env := os.Getenv(DiagnosticUploadMaxAge)
+	if env == "" {
+		return DefaultDiagnosticUploadMaxAge
+	}
+	d, err := parseDurationOrSeconds(env)
+	if err != nil {
+		log.Errorf(ctx, err, "Parsing %s=%q failed. Will use default: %s",
+			DiagnosticUploadMaxAge, env, DefaultDiagnosticUploadMaxAge)
+		return DefaultDiagnosticUploadMaxAge
+	}
+	return d
+}
+
+// PendingMaxBytes returns the cap on combined size of pending dump files.
+// Configured via DIAGNOSTIC_PENDING_MAX_BYTES; accepts SI suffixes K/M/G/T (×1000)
+// and binary suffixes Ki/Mi/Gi/Ti (×1024). A bare integer is interpreted as bytes.
+// Default is 10 GiB.
+func PendingMaxBytes(ctx context.Context) int64 {
+	env := os.Getenv(DiagnosticPendingMaxBytes)
+	if env == "" {
+		return DefaultDiagnosticPendingMaxBytes
+	}
+	n, err := parseByteSize(env)
+	if err != nil {
+		log.Errorf(ctx, err, "Parsing %s=%q failed. Will use default: %d bytes",
+			DiagnosticPendingMaxBytes, env, DefaultDiagnosticPendingMaxBytes)
+		return DefaultDiagnosticPendingMaxBytes
+	}
+	return n
+}
+
+var byteSizeRE = regexp.MustCompile(`^\s*([0-9]+)\s*([KkMmGgTt][Ii]?[Bb]?)?\s*$`)
+
+func parseByteSize(s string) (int64, error) {
+	m := byteSizeRE.FindStringSubmatch(s)
+	if m == nil {
+		return 0, fmt.Errorf("invalid byte size: %q", s)
+	}
+	n, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid byte size number in %q: %w", s, err)
+	}
+	suffix := strings.TrimSuffix(strings.ToUpper(m[2]), "B")
+	var mult int64
+	switch suffix {
+	case "":
+		mult = 1
+	case "K":
+		mult = 1000
+	case "M":
+		mult = 1000 * 1000
+	case "G":
+		mult = 1000 * 1000 * 1000
+	case "T":
+		mult = 1000 * 1000 * 1000 * 1000
+	case "KI":
+		mult = 1024
+	case "MI":
+		mult = 1024 * 1024
+	case "GI":
+		mult = 1024 * 1024 * 1024
+	case "TI":
+		mult = 1024 * 1024 * 1024 * 1024
+	default:
+		return 0, fmt.Errorf("unsupported byte size suffix in %q", s)
+	}
+	if n > 0 && mult > 0 && n > (1<<62)/mult {
+		return 0, fmt.Errorf("byte size overflow: %q", s)
+	}
+	return n * mult, nil
+}

--- a/diagtools/constants/helpers_test.go
+++ b/diagtools/constants/helpers_test.go
@@ -20,6 +20,63 @@ func init() {
 	isTest = true
 }
 
+func TestParseByteSize(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		{"0", 0},
+		{"1024", 1024},
+		{"10K", 10 * 1000},
+		{"10k", 10 * 1000},
+		{"10Ki", 10 * 1024},
+		{"10KiB", 10 * 1024},
+		{"5M", 5 * 1000 * 1000},
+		{"5Mi", 5 * 1024 * 1024},
+		{"10G", 10 * 1000 * 1000 * 1000},
+		{"10Gi", 10 * 1024 * 1024 * 1024},
+		{"1T", 1000 * 1000 * 1000 * 1000},
+		{"  2Gi  ", 2 * 1024 * 1024 * 1024},
+	}
+	for _, c := range cases {
+		got, err := parseByteSize(c.in)
+		assert.NoError(t, err, c.in)
+		assert.Equal(t, c.want, got, c.in)
+	}
+}
+
+func TestParseByteSize_Invalid(t *testing.T) {
+	for _, s := range []string{"", "abc", "10XY", "-5G", "1.5G"} {
+		_, err := parseByteSize(s)
+		assert.Error(t, err, s)
+	}
+}
+
+func TestUploadMaxAge(t *testing.T) {
+	t.Setenv(DiagnosticUploadMaxAge, "")
+	assert.Equal(t, DefaultDiagnosticUploadMaxAge, UploadMaxAge(testCtx))
+
+	t.Setenv(DiagnosticUploadMaxAge, "72h")
+	assert.Equal(t, 72*time.Hour, UploadMaxAge(testCtx))
+
+	t.Setenv(DiagnosticUploadMaxAge, "not-a-duration")
+	assert.Equal(t, DefaultDiagnosticUploadMaxAge, UploadMaxAge(testCtx))
+}
+
+func TestPendingMaxBytes(t *testing.T) {
+	t.Setenv(DiagnosticPendingMaxBytes, "")
+	assert.Equal(t, DefaultDiagnosticPendingMaxBytes, PendingMaxBytes(testCtx))
+
+	t.Setenv(DiagnosticPendingMaxBytes, "5G")
+	assert.Equal(t, int64(5*1000*1000*1000), PendingMaxBytes(testCtx))
+
+	t.Setenv(DiagnosticPendingMaxBytes, "5Gi")
+	assert.Equal(t, int64(5*1024*1024*1024), PendingMaxBytes(testCtx))
+
+	t.Setenv(DiagnosticPendingMaxBytes, "garbage")
+	assert.Equal(t, DefaultDiagnosticPendingMaxBytes, PendingMaxBytes(testCtx))
+}
+
 func saveFile(property string, val []byte) error {
 	if val == nil {
 		return nil

--- a/diagtools/constants/names.go
+++ b/diagtools/constants/names.go
@@ -29,6 +29,13 @@ const (
 	NcDiagDumpInterval      = "DIAGNOSTIC_DUMP_INTERVAL"
 	NcDiagScanInterval      = "DIAGNOSTIC_SCAN_INTERVAL"
 	NcDiagUploadTimeout     = "DIAGNOSTIC_UPLOAD_TIMEOUT" // HTTP client timeout for sending dump files (default 5m)
+	// DiagnosticUploadMaxAge deletes any pending *.hprof* file with mtime older than this
+	// from NC_DIAGNOSTIC_LOGS_FOLDER on every scan tick. Accepts Go duration syntax (e.g. "48h").
+	DiagnosticUploadMaxAge = "DIAGNOSTIC_UPLOAD_MAX_AGE"
+	// DiagnosticPendingMaxBytes caps combined size of pending *.hprof* in NC_DIAGNOSTIC_LOGS_FOLDER.
+	// When exceeded, oldest files are deleted (by mtime) until total is at or below the limit,
+	// keeping at least the newest file. Accepts K/M/G/T (×1000) and Ki/Mi/Gi/Ti (×1024) suffixes.
+	DiagnosticPendingMaxBytes = "DIAGNOSTIC_PENDING_MAX_BYTES"
 	NcProfilerFolder        = "PROFILER_FOLDER"
 	ZipCompressionLevel     = "NC_HEAP_DUMP_COMPRESSION_LEVEL"
 	NcCloudNamespace        = "CLOUD_NAMESPACE"

--- a/diagtools/handlers/handlers.go
+++ b/diagtools/handlers/handlers.go
@@ -102,12 +102,25 @@ func HandleScanCmd(ctx context.Context, args []string) (err error) {
 
 // createAndZipScan finds dump files and compresses any raw .hprof into .zip.
 // The returned action has FilesToSend populated but nothing uploaded yet.
+//
+// Before scanning, enforces retention on the same patterns (max age and
+// combined-size quota) so that crash artifacts the collector never accepted
+// don't pile up forever on disk — see DIAGNOSTIC_UPLOAD_MAX_AGE and
+// DIAGNOSTIC_PENDING_MAX_BYTES. Applies to every scan path, including
+// ad-hoc `diagtools scan *.hprof* ./core* ./hs_err*` and the scheduled scan.
 func createAndZipScan(ctx context.Context, args []string) (action actions2.ScanAction, err error) {
 	if len(args) == 0 {
 		err = fmt.Errorf("no scan patterns")
 		log.Error(ctx, err, "there are no file patterns as arguments")
 		return
 	}
+
+	actions2.CleanupStaleDumps(
+		ctx,
+		args,
+		constants.UploadMaxAge(ctx),
+		constants.PendingMaxBytes(ctx),
+	)
 
 	action, err = actions2.CreateScanAction(ctx)
 	if err != nil {

--- a/diagtools/log/logger.go
+++ b/diagtools/log/logger.go
@@ -128,6 +128,14 @@ func Error(ctx context.Context, err error, msg string, args ...any) {
 	Log(ctx).ErrorContext(ctx, msg, args...)
 }
 
+func Warnf(ctx context.Context, msg string, args ...any) {
+	Log(ctx).WarnContext(ctx, fmt.Sprintf(msg, args...))
+}
+
+func Warn(ctx context.Context, msg string, args ...any) {
+	Log(ctx).WarnContext(ctx, msg, args...)
+}
+
 func IsInfoEnabled(ctx context.Context) bool {
 	return logger.Enabled(ctx, slog.LevelInfo)
 }


### PR DESCRIPTION
Why
---
Issue #666: pending heap dumps, core files and hs_err_pid* in NC_DIAGNOSTIC_LOGS_FOLDER could accumulate indefinitely when uploads to dumps-collector kept failing (network outage, permanent rejection, etc). The existing exponential backoff in HandleScheduleCmd caps retry *frequency* but not retry *count* — a file the collector won't accept was retried forever and stayed on disk forever.

What
----
Two new env variables, enforced on every scan tick before the upload pass:

```
  DIAGNOSTIC_UPLOAD_MAX_AGE     (default 48h)
      Files matching *.hprof* with mtime older than this are deleted,
      including the single newest file. Semantics: "after maxAge, gone".

  DIAGNOSTIC_PENDING_MAX_BYTES  (default 10Gi)
      Safety net for disk pressure. If combined size exceeds the limit,
      oldest files (by mtime) are evicted LRU-style until total <= limit.
      The newest remaining file is always kept, even if it alone exceeds
      the cap.
```

Out of scope (intentionally unchanged): rotated gc.log.N (own KEEP_LOGS_INTERVAL), active gc.log (overwrites same URL), thread dumps (memory-only, never on disk), Java DefaultCollectorClient streaming retries (different transport).

How
---
* constants/names.go, constants.go: env names and defaults.
* constants/helpers.go: UploadMaxAge() and PendingMaxBytes() getters, plus parseByteSize() supporting K/M/G/T (x1000) and Ki/Mi/Gi/Ti (x1024) suffixes. A bare integer is interpreted as bytes.
* actions/cleanup.go: CleanupStaleDumps(ctx, patterns, maxAge, maxBytes). Two-phase: max-age sweep first (predictable), then quota eviction. Each deletion logs at WARN with filename, size, age, reason — operators can grep/alert on "deleting stale dump file".
* handlers/handlers.go: invocation in HandleScheduleCmd's scan branch, before createAndZipScan, so cleanup runs even when uploads are in backoff and not actively trying.
* log/logger.go: Warn / Warnf added (the package only had Info/Error before; WARN level is the right severity for "we're throwing away your diagnostic artifact").

Tests
-----
* actions/cleanup_test.go: empty folder, fresh-below-quota, single-too-old (verifies max_age applies even to the newest file), mixed ages, over-quota-keeps-newest, over-quota-LRU-until-under-limit, age+size composition, hprof+zip counted independently, zero disables.
* constants/helpers_test.go: parseByteSize for K/Ki/M/Mi/G/Gi/T variants and invalid inputs; UploadMaxAge / PendingMaxBytes env handling (unset / valid / invalid → default).

Persistence: no new state files. mtime is the only signal we rely on; it survives pod restarts naturally.

Fixes #666