### PR TITLE
fix(profiler-ui): add missing comma in javaModules array

### DIFF
--- a/it-e2e/e2e/tree-page.spec.ts
+++ b/it-e2e/e2e/tree-page.spec.ts
@@ -58,6 +58,15 @@ test('tree page shows call tree for Main.doWork', async ({ page, context }) => {
   await expect(callTree).toContainText('Main.test(String)');
   await expect(mainTestArg).toBeVisible({ timeout: 15_000 });
 
+  // Switch to the Hotspots tab and verify Main.doWork appears there
+  await treePage.locator('a[href="#tabs-hotspots"]').click();
+
+  // Hotspot computation runs in setTimeout slices and removes #hsStatus when done
+  await expect(treePage.locator('#hsStatus')).toHaveCount(0, { timeout: 15_000 });
+
+  const hotspots = treePage.locator('#hotspots');
+  await expect(hotspots).toContainText('Main.doWork', { timeout: 15_000 });
+
   // Verify no JavaScript errors occurred
   expect(jsErrors, `JavaScript errors on tree page: ${jsErrors.join('; ')}`).toHaveLength(0);
 });

--- a/profiler-ui/src/profiler.mjs
+++ b/profiler-ui/src/profiler.mjs
@@ -3447,7 +3447,7 @@ window.isDump = isDump;
 
                 ['db', 'org.postgresql.'],
 
-                ['profiler', 'com.netcracker.profiler.']
+                ['profiler', 'com.netcracker.profiler.'],
 
                 ['org.quartz', 'org.quartz.'],
 


### PR DESCRIPTION
## Summary
- Add the missing comma between the `profiler` and `org.quartz` entries in the `javaModules` array in `profiler-ui/src/profiler.mjs`.
- Without the comma, JS parsed the next line as `arr['org.quartz', 'org.quartz.']` — a comma-operator inside an index expression — which evaluated to `undefined`, leaving a hole in `javaModules`.
- The hole was masked on the tree tab (sort skips `undefined`), but blew up the hotspots tab with `TypeError: Cannot read properties of undefined (reading '1')` inside `eo()` when it iterated the array by index.

## Test plan
- [ ] Open a generated dump HTML, verify the call tree still renders.
- [ ] Switch to the hotspots tab and confirm it computes without console errors.
- [ ] Confirm `org.quartz` calls are correctly grouped under their own module bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)