### PR TITLE
fix: added the Kubernetes labels to fix RW failure

### DIFF
--- a/backend/charts/dumps-collector/templates/_helpers.tpl
+++ b/backend/charts/dumps-collector/templates/_helpers.tpl
@@ -10,11 +10,7 @@ app: {{ .name }}
 name: {{ .name }}
 app.kubernetes.io/name: {{ .name }}
 app.kubernetes.io/instance: {{ .name }}
-{{- if .serviceMonitor }}
-  {{- print "app.kubernetes.io/component: monitoring" | nindent 0 }}
-{{- else }}
-  {{- printf "%s: %s" "app.kubernetes.io/component" "backend" | nindent 0 }}
-{{- end }}
+app.kubernetes.io/part-of: {{ .name }}
 {{- if .labels }}
 {{ .labels | toYaml }}
 {{- end }}
@@ -24,9 +20,10 @@ app.kubernetes.io/instance: {{ .name }}
 Create common labels for each resource which is creating by this chart.
 */}}
 {{- define "common.commonLabels" -}}
-app.kubernetes.io/part-of: {{ .name }}
 app.kubernetes.io/managed-by: Helm
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/technology: 'go'
+app.kubernetes.io/component: backend
 {{- end -}}
 
 {{/******************************************************************************************************************/}}

--- a/backend/charts/dumps-collector/templates/_helpers.tpl
+++ b/backend/charts/dumps-collector/templates/_helpers.tpl
@@ -7,12 +7,13 @@ Create common labels for each resource which is creating by this chart.
 */}}
 {{- define "common.namedLabels" -}}
 app: {{ .name }}
+name: {{ .name }}
 app.kubernetes.io/name: {{ .name }}
 app.kubernetes.io/instance: {{ .name }}
 {{- if .serviceMonitor }}
   {{- print "app.kubernetes.io/component: monitoring" | nindent 0 }}
 {{- else }}
-  {{- printf "%s: %s" "app.kubernetes.io/component" .name | nindent 0 }}
+  {{- printf "%s: %s" "app.kubernetes.io/component" "backend" | nindent 0 }}
 {{- end }}
 {{- if .labels }}
 {{ .labels | toYaml }}
@@ -24,7 +25,7 @@ Create common labels for each resource which is creating by this chart.
 */}}
 {{- define "common.commonLabels" -}}
 app.kubernetes.io/part-of: cloud-profiler
-app.kubernetes.io/managed-by: helm
+app.kubernetes.io/managed-by: Helm
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 

--- a/backend/charts/dumps-collector/templates/_helpers.tpl
+++ b/backend/charts/dumps-collector/templates/_helpers.tpl
@@ -24,7 +24,7 @@ app.kubernetes.io/instance: {{ .name }}
 Create common labels for each resource which is creating by this chart.
 */}}
 {{- define "common.commonLabels" -}}
-app.kubernetes.io/part-of: cloud-profiler
+app.kubernetes.io/part-of: cloud-profiler-dumps-collector
 app.kubernetes.io/managed-by: Helm
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}

--- a/backend/charts/dumps-collector/templates/_helpers.tpl
+++ b/backend/charts/dumps-collector/templates/_helpers.tpl
@@ -24,7 +24,7 @@ app.kubernetes.io/instance: {{ .name }}
 Create common labels for each resource which is creating by this chart.
 */}}
 {{- define "common.commonLabels" -}}
-app.kubernetes.io/part-of: cloud-profiler-dumps-collector
+app.kubernetes.io/part-of: {{ .name }}
 app.kubernetes.io/managed-by: Helm
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}

--- a/backend/charts/dumps-collector/templates/deployment.yaml
+++ b/backend/charts/dumps-collector/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "common.namedLabels" .Values.dumpsCollector | nindent 4 }}
     {{- include "common.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/technology: 'go'
   annotations:
   {{- toYaml .Values.dumpsCollector.annotations | nindent 4 }}
 spec:
@@ -23,6 +24,7 @@ spec:
       labels:
         {{- include "common.namedLabels" .Values.dumpsCollector | nindent 8 }}
         {{- include "common.commonLabels" . | nindent 8 }}
+        app.kubernetes.io/technology: 'go'
     spec:
       {{- if .Values.dumpsCollector.nodeSelector }}
       nodeSelector: {{ toYaml .Values.dumpsCollector.nodeSelector | nindent 8 }}

--- a/backend/charts/dumps-collector/templates/deployment.yaml
+++ b/backend/charts/dumps-collector/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "common.namedLabels" .Values.dumpsCollector | nindent 4 }}
     {{- include "common.commonLabels" . | nindent 4 }}
-    app.kubernetes.io/technology: 'go'
   annotations:
   {{- toYaml .Values.dumpsCollector.annotations | nindent 4 }}
 spec:
@@ -24,7 +23,6 @@ spec:
       labels:
         {{- include "common.namedLabels" .Values.dumpsCollector | nindent 8 }}
         {{- include "common.commonLabels" . | nindent 8 }}
-        app.kubernetes.io/technology: 'go'
     spec:
       {{- if .Values.dumpsCollector.nodeSelector }}
       nodeSelector: {{ toYaml .Values.dumpsCollector.nodeSelector | nindent 8 }}

--- a/backend/charts/dumps-collector/templates/ingress.yaml
+++ b/backend/charts/dumps-collector/templates/ingress.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     {{- include "common.namedLabels" .Values.dumpsCollector | nindent 4 }}
     {{- include "common.commonLabels" . | nindent 4 }}
+    deployment.netcracker.com/ingress-type: private-network
+    deployment.netcracker.com/ingress-audience-type: ops-user
   {{- if or (eq (include "isTlsGenerateCertsEnabled" .) "true") (eq (include "isTlsUseExistingCertsEnabled" .) "true") }}
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"


### PR DESCRIPTION
# Pull Request

## Describe Your Changes

Added the Kubernetes labels for dump collector to pass the RW. 
Below are the added k8s labels
name
deployment.netcracker.com/ingress-audience-type
deployment.netcracker.com/ingress-type 
app.kubernetes.io/technology

## Checklist

The following checks are **mandatory**:

* [ ] My change adheres [Qubership contributing guidelines](../CONTRIBUTING.md).
