### PR TITLE
fix(boot): handle Spring Session non-public request wrappers

### DIFF
--- a/.github/workflows/gradle-dependency-submit.yaml
+++ b/.github/workflows/gradle-dependency-submit.yaml
@@ -32,6 +32,8 @@ jobs:
       with:
         # Profiler plugins do not expose the dependencies to the runtime, so the versions used for the build
         # do not affect the execution. At the same time, we might need to build plugins for different thirdparty
-        # versions, so we intentionally exclude :plugins:* projects from the submitted dependencies
+        # versions, so we intentionally exclude :plugins:* projects from the submitted dependencies.
+        # :sample-apps:* are pinned to specific framework majors (e.g. Spring Boot 3.x) on purpose and should not
+        # generate security alerts for the profiler agent project.
         dependency-graph-exclude-projects: |
-          :plugins:.*
+          :plugins:.*|:sample-apps:.*

--- a/backend/examples/spring-boot-3-undertow/pom.xml
+++ b/backend/examples/spring-boot-3-undertow/pom.xml
@@ -45,6 +45,16 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
+        <!--
+            Spring Session is enabled so the demo exercises a real-world filter chain that wraps
+            requests in SessionRepositoryFilter$SessionRepositoryRequestWrapper. This is the
+            production scenario that previously triggered IllegalAccessException in the profiler's
+            HttpServletRequestAdapter (see sample-apps/it-spring-boot-3 integration test).
+        -->
+        <dependency>
+            <groupId>org.springframework.session</groupId>
+            <artifactId>spring-session-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/examples/spring-boot-3-undertow/src/main/java/com/netcracker/monitoring/metrics/SessionConfig.java
+++ b/backend/examples/spring-boot-3-undertow/src/main/java/com/netcracker/monitoring/metrics/SessionConfig.java
@@ -1,0 +1,39 @@
+package com.netcracker.monitoring.metrics;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.MapSession;
+import org.springframework.session.MapSessionRepository;
+import org.springframework.session.web.http.SessionRepositoryFilter;
+
+/**
+ * Wires Spring Session with an in-memory repository so that every incoming HTTP request is
+ * wrapped in {@code SessionRepositoryFilter$SessionRepositoryRequestWrapper}. This recreates
+ * the production scenario that previously surfaced IllegalAccessException in the profiler's
+ * HttpServletRequestAdapter when running against Undertow + Spring Session.
+ *
+ * The filter is constructed and registered explicitly so the behavior is independent of which
+ * Spring Boot session auto-configuration is active for the current spring-session-core version.
+ */
+@Configuration
+public class SessionConfig {
+
+    @Bean
+    public MapSessionRepository sessionRepository() {
+        return new MapSessionRepository(new ConcurrentHashMap<>());
+    }
+
+    @Bean
+    public FilterRegistrationBean<SessionRepositoryFilter<MapSession>> sessionFilterRegistration(
+            MapSessionRepository repository) {
+        SessionRepositoryFilter<MapSession> filter = new SessionRepositoryFilter<>(repository);
+        FilterRegistrationBean<SessionRepositoryFilter<MapSession>> registration =
+                new FilterRegistrationBean<>(filter);
+        registration.addUrlPatterns("/*");
+        registration.setOrder(Integer.MIN_VALUE + 50);
+        return registration;
+    }
+}

--- a/boot/src/main/java/com/netcracker/profiler/agent/http/CookieAdapter.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/http/CookieAdapter.java
@@ -10,8 +10,13 @@ public class CookieAdapter {
 
     public CookieAdapter(Object cookie) throws NoSuchMethodException {
         this.cookie = cookie;
-        this.getName = cookie.getClass().getDeclaredMethod("getName");
-        this.getValue = cookie.getClass().getDeclaredMethod("getValue");
+        // getMethod (not getDeclaredMethod) walks the inheritance chain — works even when the
+        // concrete cookie class doesn't override the accessors. setAccessible bypasses the language
+        // access check when the declaring class is non-public (see HttpServletRequestAdapter).
+        this.getName = cookie.getClass().getMethod("getName");
+        this.getName.setAccessible(true);
+        this.getValue = cookie.getClass().getMethod("getValue");
+        this.getValue.setAccessible(true);
     }
 
     public String getName() throws InvocationTargetException, IllegalAccessException {

--- a/boot/src/main/java/com/netcracker/profiler/agent/http/HttpServletRequestAdapter.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/http/HttpServletRequestAdapter.java
@@ -16,14 +16,26 @@ public class HttpServletRequestAdapter {
 
     public HttpServletRequestAdapter(Object httpServletRequest) throws NoSuchMethodException {
         this.httpServletRequest = httpServletRequest;
+        // Spring Session wraps the request in a non-public inner class (SessionRepositoryRequestWrapper).
+        // Class.getMethod returns a Method whose declaringClass is that wrapper, and Method.invoke
+        // performs an access check against the declaring class modifiers — so we must setAccessible(true)
+        // even for methods declared public on a public ancestor interface.
         getSession = this.httpServletRequest.getClass().getMethod("getSession", boolean.class);
+        getSession.setAccessible(true);
         getRequestURL = this.httpServletRequest.getClass().getMethod("getRequestURL");
+        getRequestURL.setAccessible(true);
         getQueryString = this.httpServletRequest.getClass().getMethod("getQueryString");
+        getQueryString.setAccessible(true);
         getRequestedSessionId = this.httpServletRequest.getClass().getMethod("getRequestedSessionId");
+        getRequestedSessionId.setAccessible(true);
         getMethod = this.httpServletRequest.getClass().getMethod("getMethod");
+        getMethod.setAccessible(true);
         getHeader = this.httpServletRequest.getClass().getMethod("getHeader", String.class);
+        getHeader.setAccessible(true);
         getCookies = this.httpServletRequest.getClass().getMethod("getCookies");
+        getCookies.setAccessible(true);
         setAttribute = this.httpServletRequest.getClass().getMethod("setAttribute", String.class, Object.class);
+        setAttribute.setAccessible(true);
     }
 
     public HttpSessionAdapter getSession(boolean createSession) throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {

--- a/boot/src/main/java/com/netcracker/profiler/agent/http/HttpSessionAdapter.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/http/HttpSessionAdapter.java
@@ -10,6 +10,8 @@ public class HttpSessionAdapter {
     public HttpSessionAdapter(Object httpSession) throws NoSuchMethodException {
         this.httpSession = httpSession;
         getAttribute = this.httpSession.getClass().getMethod("getAttribute", String.class);
+        // Some session implementations are non-public wrapper classes (see HttpServletRequestAdapter).
+        getAttribute.setAccessible(true);
     }
 
     public Object getAttribute(String name) throws InvocationTargetException, IllegalAccessException {

--- a/boot/src/main/java/com/netcracker/profiler/agent/http/ServletRequestAdapter.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/http/ServletRequestAdapter.java
@@ -16,20 +16,25 @@ public class ServletRequestAdapter {
     public ServletRequestAdapter(Object servletRequest) throws ClassNotFoundException, NoSuchMethodException {
         this.servletRequest = servletRequest;
 
+        // setAccessible(true) handles non-public wrapper classes (e.g. Spring Session's
+        // SessionRepositoryRequestWrapper) whose declaring class modifiers fail Method.invoke access checks.
         try {
             getRemoteAddr = servletRequest.getClass().getMethod("getRemoteAddr");
+            getRemoteAddr.setAccessible(true);
         } catch (NoSuchMethodException e) {
             logger.severe("ServletRequest should have method getRemoteAddr", e);
         }
 
         try {
             getRemoteHost = servletRequest.getClass().getMethod("getRemoteHost");
+            getRemoteHost.setAccessible(true);
         } catch (NoSuchMethodException e) {
             logger.severe("ServletRequest should have method getRemoteHost", e);
         }
 
         try {
             setAttribute = servletRequest.getClass().getMethod("setAttribute", String.class, Object.class);
+            setAttribute.setAccessible(true);
         } catch (NoSuchMethodException e) {
             logger.severe("ServletRequest should have method setAttribute", e);
         }

--- a/build-logic/jvm/src/main/kotlin/build-logic.java-17-library.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.java-17-library.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    id("build-logic.java-library")
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release = 17
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}

--- a/installer-zip-test/build.gradle.kts
+++ b/installer-zip-test/build.gradle.kts
@@ -22,6 +22,10 @@ val installerZip = configurations.resolvable("installerZip") {
 dependencies {
     installerZipElements(projects.installer)
     testCompileOnly(projects.boot)
+    // Drives the minimal logback-visibility reproducer: the test reconfigures Logback the way a
+    // host application (e.g. Spring Boot) would, then checks whether the agent's plugin logger
+    // still reaches that configuration.
+    testImplementation("ch.qos.logback:logback-classic")
 }
 
 val profilerHome = layout.buildDirectory.dir("profiler-home")

--- a/installer-zip-test/src/test/kotlin/com/netcracker/profiler/logging/PluginLoggerVisibilityTest.kt
+++ b/installer-zip-test/src/test/kotlin/com/netcracker/profiler/logging/PluginLoggerVisibilityTest.kt
@@ -1,0 +1,140 @@
+package com.netcracker.profiler.logging
+
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.joran.JoranConfigurator
+import com.netcracker.profiler.agent.Profiler
+import com.netcracker.profiler.agent.ProfilerData
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.nio.charset.StandardCharsets
+
+/**
+ * Minimal, isolated characterization of the plugin-logger visibility problem — no HTTP, no
+ * Spring, no bytecode instrumentation, runs in ~1s.
+ *
+ * Symptom (seen in production and in the it-spring-boot-3 integration test): a swallowed plugin
+ * exception routed through [Profiler.pluginException] never shows up in the host application's
+ * log, so the `it-spring-boot-3` test has to rely on the fail-loud
+ * `com.netcracker.profiler.agent.echoPluginExceptionToStderr` property instead.
+ *
+ * Root cause demonstrated here: the agent does NOT share Logback with the application. Its
+ * `ProfilerPluginLoggerImpl` logger is created through the agent's own
+ * `com.netcracker.profiler.agent.PluginClassLoader`, which loads a *separate* copy of
+ * logback-classic with its *own* [LoggerContext]. Consequently:
+ *  - reconfiguring the application's `LoggerContext` (exactly what Spring Boot's
+ *    `LoggingApplicationListener` does on startup) has no effect on the agent's logger, and
+ *  - plugin errors land only in the agent context's own appenders (the STDOUT appender from
+ *    `profiler-home/config/logback.xml`), never in the appenders the application configured.
+ *
+ * The assertions below lock in that root cause. When the agent gains a deliberate, documented
+ * bridge for surfacing plugin errors (e.g. routing them to the application's logging pipeline,
+ * or the gated stderr echo becoming the supported channel), update this test accordingly.
+ */
+class PluginLoggerVisibilityTest {
+
+    @Test
+    fun `agent plugin logger is isolated from the application Logback context`() {
+        // The agent must be attached and initialized, otherwise the scenario is meaningless.
+        assertNotNull(
+            ProfilerData.pluginLogger,
+            "ProfilerData.pluginLogger is null — the profiler agent is not attached/initialized; " +
+                "this test must run under -javaagent (installer-zip-test wires that up).",
+        )
+
+        val logFile = File.createTempFile("plugin-logger-visibility", ".log").apply { deleteOnExit() }
+
+        // Reconfigure Logback the way a host application (Spring Boot) does on startup: reset the
+        // global context and re-apply a config — here everything goes to a known file.
+        val appContext = LoggerFactory.getILoggerFactory() as LoggerContext
+        appContext.reset()
+        JoranConfigurator().apply {
+            context = appContext
+            doConfigure(
+                ByteArrayInputStream(
+                    """
+                    <configuration>
+                      <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+                        <file>${logFile.absolutePath}</file>
+                        <append>false</append>
+                        <encoder><pattern>%-5level %logger - %msg%n%rEx</pattern></encoder>
+                      </appender>
+                      <root level="INFO">
+                        <appender-ref ref="FILE"/>
+                      </root>
+                    </configuration>
+                    """.trimIndent().toByteArray(StandardCharsets.UTF_8),
+                ),
+            )
+        }
+
+        // Note: the agent's LoggerContext is an instance of ch.qos.logback.classic.LoggerContext
+        // loaded by the agent's PluginClassLoader — a DIFFERENT Class object than the
+        // application's same-named LoggerContext (AppClassLoader). So we keep it as Any? and never
+        // cast it to the application's type (that cast would itself throw ClassCastException —
+        // which is, in fact, further proof of the isolation).
+        val agentContext: Any? = agentLoggerContext()
+        val agentContextClassLoader = agentContext?.javaClass?.classLoader
+        println("[diag] application LoggerContext = ${id(appContext)} (CL ${cl(appContext.javaClass)})")
+        println("[diag] agent       LoggerContext = ${id(agentContext)} (CL ${agentContextClassLoader ?: "bootstrap"})")
+        println("[diag] agent pluginLogger        = ${id(ProfilerData.pluginLogger)}")
+
+        // Fire the swallowed plugin exception through the agent's logger, then flush the app file.
+        Profiler.pluginException(RuntimeException("sentinel-plugin-error"))
+        appContext.stop()
+
+        val captured = logFile.readText(StandardCharsets.UTF_8)
+        println("[diag] captured app-file length  = ${captured.length}")
+
+        // (1) The agent logs through a different LoggerContext than the application.
+        assertNotNull(agentContext, "Could not introspect the agent's Logback LoggerContext")
+        assertNotSame(
+            appContext,
+            agentContext,
+            "Expected the agent to use a LoggerContext isolated from the application's, " +
+                "but they are the same instance.",
+        )
+        // The isolation is rooted in a separate logback-classic copy: the agent's LoggerContext is
+        // loaded by the agent's PluginClassLoader, not by the application classloader.
+        assertNotSame(
+            appContext.javaClass.classLoader,
+            agentContextClassLoader,
+            "Expected the agent's logback-classic to be loaded by a different classloader " +
+                "than the application's, but both came from the same classloader.",
+        )
+
+        // (2) Therefore the application-configured appender never receives the plugin error.
+        assertEquals(
+            "",
+            captured,
+            "Plugin error unexpectedly reached the application-configured Logback appender. " +
+                "If the agent now bridges into the application's logging pipeline, update this test. " +
+                "Captured:\n$captured",
+        )
+    }
+
+    /**
+     * Reflectively obtains the Logback `LoggerContext` backing the agent's ProfilerPluginLoggerImpl
+     * logger. Returned as [Any] on purpose: that context is a `ch.qos.logback.classic.LoggerContext`
+     * loaded by the agent's PluginClassLoader, which is a different `Class` than this test's
+     * same-named type, so it must not be cast.
+     */
+    private fun agentLoggerContext(): Any? {
+        val pluginLogger = ProfilerData.pluginLogger ?: return null
+        return runCatching {
+            val loggerField = pluginLogger.javaClass.getDeclaredField("logger").apply { isAccessible = true }
+            val slf4jLogger = loggerField.get(pluginLogger)
+            val getContext = slf4jLogger.javaClass.methods.first { it.name == "getLoggerContext" }
+            getContext.invoke(slf4jLogger)
+        }.getOrNull()
+    }
+
+    private fun id(o: Any?): String =
+        if (o == null) "null" else "${o.javaClass.name}@${System.identityHashCode(o).toString(16)}"
+
+    private fun cl(c: Class<*>): String = c.classLoader?.toString() ?: "bootstrap"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -115,6 +115,19 @@
       ]
     },
     {
+      "description": "Pin sample-apps/it-spring-boot-3 to Spring Boot 3.x; create it-spring-boot-4 module when bumping major",
+      "groupName": "Spring Boot 3 sample app",
+      "matchFileNames": [
+        "sample-apps/it-spring-boot-3/**"
+      ],
+      "allowedVersions": "< 4",
+      "matchPackageNames": [
+        "org.springframework.boot{/,}**",
+        "org.springframework{/,}**",
+        "org.springframework.session{/,}**"
+      ]
+    },
+    {
       "description": "Group all GitHub Actions updates into a single PR",
       "groupName": "GitHub Actions",
       "matchManagers": [

--- a/sample-apps/it-spring-boot-3/build.gradle.kts
+++ b/sample-apps/it-spring-boot-3/build.gradle.kts
@@ -1,0 +1,69 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+plugins {
+    id("build-logic.java-17-library")
+    id("build-logic.kotlin")
+    id("build-logic.test-junit5")
+}
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+        freeCompilerArgs.add("-Xjdk-release=17")
+    }
+}
+
+dependencies {
+    val testcontainersBom = enforcedPlatform("org.testcontainers:testcontainers-bom:1.21.0")
+    testImplementation(testcontainersBom)
+    testImplementation("org.testcontainers:testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+}
+
+val demoModuleDir = rootDir.resolve("backend/examples/spring-boot-3-undertow")
+val demoTargetDir = demoModuleDir.resolve("target")
+
+// Build the existing Maven demo (Spring Boot 3 + Undertow + Spring Session). The demo doubles
+// as the test fixture — same source code shipped as a deployable sample. The test packages this
+// jar on top of qubership/qubership-core-base-image:profiler-latest, which already has the
+// profiler agent baked into /app/diag and wires -javaagent via its entrypoint when
+// NC_DIAGNOSTIC_MODE=prod.
+val buildDemoApp by tasks.registering(Exec::class) {
+    workingDir = demoModuleDir
+    executable = "mvn"
+    args("package", "-DskipTests", "-q")
+
+    inputs.file(demoModuleDir.resolve("pom.xml"))
+    inputs.dir(demoModuleDir.resolve("src"))
+    outputs.dir(demoTargetDir)
+}
+
+val demoJarProvider = buildDemoApp.map {
+    fileTree(demoTargetDir) {
+        include("*.jar")
+        exclude("original-*", "*-sources.jar", "*-javadoc.jar")
+    }.singleFile
+}
+
+tasks.test {
+    dependsOn(buildDemoApp, ":installer:buildBaseImage")
+
+    inputs.files(demoTargetDir).withPropertyName("demoTarget").withPathSensitivity(PathSensitivity.RELATIVE)
+
+    systemProperty("test.baseImageTag", "qubership/qubership-core-base-image:profiler-latest")
+
+    // docker-java 3.x bundled with Testcontainers 1.21 advertises Docker API 1.32 by default,
+    // which modern Docker daemons (OrbStack, Docker Desktop ≥ 25) reject with
+    // "client version 1.32 is too old". Force a newer negotiated API version.
+    systemProperty("api.version", "1.43")
+
+    // Resolve the demo jar lazily, at execution time: buildDemoApp populates target/ only when it
+    // runs, so reading demoJarProvider.get() during configuration fails on a clean checkout
+    // (empty target/). A CommandLineArgumentProvider defers it until the command line is built.
+    jvmArgumentProviders.add(
+        CommandLineArgumentProvider {
+            listOf("-Dtest.demoAppJar=${demoJarProvider.get().absolutePath}")
+        },
+    )
+}

--- a/sample-apps/it-spring-boot-3/src/test/kotlin/com/netcracker/profiler/test/spring/HttpServletRequestAdapterSpringSessionTest.kt
+++ b/sample-apps/it-spring-boot-3/src/test/kotlin/com/netcracker/profiler/test/spring/HttpServletRequestAdapterSpringSessionTest.kt
@@ -1,0 +1,122 @@
+package com.netcracker.profiler.test.spring
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.images.builder.ImageFromDockerfile
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Duration
+
+/**
+ * End-to-end reproduction of the production IllegalAccessException.
+ *
+ * Setup:
+ *  - `backend/examples/spring-boot-3-undertow` is packaged by Maven into a Spring Boot fat jar.
+ *  - The test layers that jar on top of `qubership/qubership-core-base-image:profiler-latest`
+ *    (built by the `:installer:buildBaseImage` task). The base image already has the profiler
+ *    agent installed under `/app/diag` and wires `-javaagent:/app/diag/lib/agent.jar` via its
+ *    entrypoint when `NC_DIAGNOSTIC_MODE=prod`.
+ *  - Testcontainers manages the container lifecycle, exposing a random host port.
+ *
+ * Why a real container:
+ *  - The agent's bytecode instrumentation fires against the real Undertow
+ *    `FilterHandler$FilterChainImpl.doFilter` — the exact call site from the production
+ *    stacktrace. Same image, same agent layout, same JAVA_TOOL_OPTIONS as production.
+ *
+ * How the bug is detected:
+ *  - The agent loads its OWN isolated Logback (via its PluginClassLoader), so plugin exceptions
+ *    never reach the application's log. We point the agent at a dedicated Logback config through
+ *    its supported `-Dprofiler.log.config` switch (test resource `agent-logback.xml`) that writes
+ *    everything — including `ProfilerPluginLoggerImpl` errors — to `/tmp/agent-plugin.log`. After
+ *    the request we copy that file out of the container and assert it carries no swallowed
+ *    `IllegalAccessException` against `SessionRepositoryRequestWrapper`.
+ *
+ * See `installer-zip-test/.../PluginLoggerVisibilityTest` for the isolated characterization of why
+ * the agent's Logback is separate from the application's.
+ */
+class HttpServletRequestAdapterSpringSessionTest {
+
+    @Test
+    fun `agent does not raise IllegalAccessException for Spring Session wrapped request`() {
+        val demoJar: Path = Paths.get(System.getProperty("test.demoAppJar"))
+        val baseImageTag = System.getProperty("test.baseImageTag")
+
+        val image = ImageFromDockerfile("qubership-profiler-it-spring-boot-3", false)
+            .withFileFromPath("app.jar", demoJar)
+            .withFileFromClasspath("agent-logback.xml", "agent-logback.xml")
+            .withDockerfileFromBuilder { b ->
+                b
+                    .from(baseImageTag)
+                    .copy("app.jar", "/app/app.jar")
+                    .copy("agent-logback.xml", "/app/agent-logback.xml")
+                    .env("NC_DIAGNOSTIC_MODE", "prod")
+                    .expose(8080)
+                    .cmd(
+                        "java",
+                        // Route the agent's own (isolated) Logback to a file we can read back.
+                        "-Dprofiler.log.config=/app/agent-logback.xml",
+                        "-jar",
+                        "/app/app.jar",
+                    )
+                    .build()
+            }
+
+        GenericContainer(image).use { container ->
+            container.withExposedPorts(8080)
+                .waitingFor(
+                    Wait.forHttp("/health")
+                        .forStatusCode(200)
+                        .withStartupTimeout(Duration.ofMinutes(2)),
+                )
+            container.start()
+
+            val baseUrl = "http://${container.host}:${container.getMappedPort(8080)}"
+            val response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create("$baseUrl/health")).GET().build(),
+                HttpResponse.BodyHandlers.ofString(),
+            )
+            assertEquals(200, response.statusCode())
+
+            // Let the agent's FileAppender flush before copying it out.
+            Thread.sleep(500)
+
+            val agentLog = File.createTempFile("agent-plugin-", ".log").apply { deleteOnExit() }
+            try {
+                container.copyFileFromContainer("/tmp/agent-plugin.log") { input ->
+                    agentLog.outputStream().use { input.copyTo(it) }
+                }
+            } catch (_: Throwable) {
+                // No file → agent logged nothing → no plugin error. Treat as empty.
+                agentLog.writeText("")
+            }
+
+            val captured = agentLog.readText()
+            val swallowed = captured.lineSequence()
+                .filter {
+                    it.contains("IllegalAccessException") &&
+                            it.contains("SessionRepositoryRequestWrapper")
+                }
+                .toList()
+
+            assertTrue(
+                swallowed.isEmpty(),
+                buildString {
+                    appendLine("Profiler swallowed IllegalAccessException(s) for the Spring Session wrapper.")
+                    appendLine("Matched lines (${swallowed.size}):")
+                    swallowed.take(3).forEach { appendLine("  $it") }
+                    appendLine()
+                    appendLine("--- /tmp/agent-plugin.log (truncated to 4 KiB) ---")
+                    appendLine(captured.takeLast(4096).ifEmpty { "(empty)" })
+                },
+            )
+        }
+    }
+}

--- a/sample-apps/it-spring-boot-3/src/test/resources/agent-logback.xml
+++ b/sample-apps/it-spring-boot-3/src/test/resources/agent-logback.xml
@@ -1,0 +1,22 @@
+<!--
+    Logback configuration for the profiler AGENT (not the application). The agent loads its own
+    isolated copy of Logback via its PluginClassLoader, so this config is wired in through the
+    agent's own `-Dprofiler.log.config` switch (see the test's container CMD), independent of
+    whatever Logback the host application configures.
+
+    Everything the agent logs — including plugin exceptions routed through
+    ProfilerPluginLoggerImpl ("Exception in profiler plugin" + stack trace) — is written to a
+    known file the integration test copies out of the container and inspects.
+-->
+<configuration>
+    <appender name="PLUGIN_FILE" class="ch.qos.logback.core.FileAppender">
+        <file>/tmp/agent-plugin.log</file>
+        <append>false</append>
+        <encoder>
+            <pattern>%-5level %logger - %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="PLUGIN_FILE"/>
+    </root>
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ pluginManagement {
         id("com.google.osdetector") version "1.7.3"
         kotlin("jvm") version "2.3.21"
         kotlin("kapt") version "2.3.21"
+        kotlin("plugin.spring") version "2.3.21"
         id("me.champeau.jmh") version "0.7.3"
     }
 }
@@ -28,7 +29,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 rootProject.name = "qubership-profiler"
 
 gradle.allprojects {
-    if (path != ":plugins") {
+    if (path != ":plugins" && path != ":sample-apps") {
         buildscript {
             dependencies {
                 classpath(platform("com.fasterxml.jackson:jackson-bom:2.21.1"))
@@ -65,6 +66,7 @@ include("profiler")
 include("profiler-ui")
 include("proto-definition")
 include("runtime")
+include("sample-apps:it-spring-boot-3")
 include("test-config")
 include("test-app")
 include("testkit")


### PR DESCRIPTION
## Summary
- Fix `IllegalAccessException` in `HttpServletRequestAdapter` (and 3 sibling adapters) against Spring Session's `SessionRepositoryFilter$SessionRepositoryRequestWrapper` — a `private final` inner class whose declaring-class modifiers fail `Method.invoke` access checks even though the methods themselves are public.
- Add `sample-apps/it-spring-boot-3` — a new Gradle module that boots a tiny Spring Boot 3 + Spring Session app and reproduces the production stacktrace verbatim. Reverting the boot/ change makes the test fail with the same `IllegalAccessException at HttpServletRequestAdapter.java:30`.
- Infrastructure: `build-logic.java-17-library` convention; `:sample-apps:*` joins `:plugins:*` in the dependency-submission exclude list; renovate pins this module to Spring Boot 3.x (a major bump triggers a new `it-spring-boot-4` sibling).

## Test plan
- [x] `./gradlew --quiet :sample-apps:it-spring-boot-3:test` — fails before the fix, passes after
- [x] `./gradlew --quiet :boot:test` — passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)