### PR TITLE
ci(zizmor): ignore secrets-outside-env for trusted-action secrets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     env:
-      CENTRAL_PORTAL_USERNAME: ${{ secrets.MAVEN_USER }}
+      CENTRAL_PORTAL_USERNAME: ${{ secrets.MAVEN_USER }} # zizmor: ignore[secrets-outside-env]
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -75,8 +75,8 @@ jobs:
         if: ${{ env.CENTRAL_PORTAL_USERNAME != '' }}
         with:
           arguments: publishAllPublicationsToCentralSnapshotsRepository
-          properties: |
+          properties: | # zizmor: ignore[secrets-outside-env]
             centralSnapshotsUsername=${{ secrets.MAVEN_USER }}
             centralSnapshotsPassword=${{ secrets.MAVEN_PASSWORD }}
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: Netcracker/qubership-workflow-hub/actions/cla-assistant@e64a1ee2fc2f68ab44a4ef416c27d83ce36ba8e1 # v2.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }} # zizmor: ignore[secrets-outside-env]
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/Netcracker/qubership-workflow-hub/blob/release/v2.2.0/CLA/cla.md'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
         id: app_token
         with:
           app-id: ${{ vars.GH_BUMP_VERSION_APP_ID }}
-          private-key: ${{ secrets.GH_BUMP_VERSION_APP_KEY }}
+          private-key: ${{ secrets.GH_BUMP_VERSION_APP_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - name: Update version in gradle.properties to ${{ steps.release_version.outputs.version }}
         uses: ./.github/actions/update_version
@@ -141,10 +141,10 @@ jobs:
             release=true
             centralPortalPublishingType=AUTOMATIC
         env:
-          CENTRAL_PORTAL_USERNAME: ${{ secrets.MAVEN_USER }}
-          CENTRAL_PORTAL_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          SIGNING_PGP_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          SIGNING_PGP_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          CENTRAL_PORTAL_USERNAME: ${{ secrets.MAVEN_USER }} # zizmor: ignore[secrets-outside-env]
+          CENTRAL_PORTAL_PASSWORD: ${{ secrets.MAVEN_PASSWORD }} # zizmor: ignore[secrets-outside-env]
+          SIGNING_PGP_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+          SIGNING_PGP_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }} # zizmor: ignore[secrets-outside-env]
 
       - name: Publish GitHub release
         uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -62,7 +62,7 @@ jobs:
         id: ghcr
         uses: Netcracker/qubership-workflow-hub/actions/ghcr-discover-repo-packages@e64a1ee2fc2f68ab44a4ef416c27d83ce36ba8e1 # v2.2.1
         env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }} # zizmor: ignore[secrets-outside-env]
 
       - name: Print packages
         env:


### PR DESCRIPTION
## Why

super-linter lints only changed files (`VALIDATE_ALL_CODEBASE: false`). On `main` the workflow files are not in the changed set, so zizmor never scans them. Any PR that touches a workflow — for example the github-actions Renovate PR #611 — pulls these four files into scope, and zizmor reports 11 pre-existing `secrets-outside-env` findings. The Renovate bump does not introduce them; they have always been there.

All 11 are legitimate: real secrets passed through `env` or `with` to trusted first-party actions (Netcracker workflow-hub, `burrunan/gradle-cache-action`). These workflows use no GitHub environment, so the audit's dedicated-environment remedy does not fit.

## What

Add inline `# zizmor: ignore[secrets-outside-env]` comments at each flagged secret reference. The comment on the `properties: |` line in `build.yaml` covers the two findings inside its block scalar — a comment inside the block would become part of the value. Inline comments supplement the shared zizmor config copied from `netcracker/.github` rather than replacing it, so the repo keeps receiving org config updates.

## How to verify

- All four files still parse as YAML.
- The `properties:` block-scalar value is unchanged: the comment sits after the `|` indicator, not inside the value, so the publish step behaves as before.
- This PR touches the workflows, so super-linter re-scans them; its zizmor step should now report no `secrets-outside-env` findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)