### PR TITLE
fix(build): add JDK module flags for google-java-format and Error Prone

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,22 @@
 org.gradle.parallel=true
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=768m
+# google-java-format (autostyle's removeUnusedImports) and Error Prone reach into
+# jdk.compiler internals that JDK 16+ no longer exports by default. autostyle runs
+# inside the Gradle daemon, so the flags must live here rather than on the compiler
+# fork; the daemon already exporting them also keeps the errorprone plugin happy.
+# This is Error Prone's canonical JDK 16+ set, a superset of google-java-format's.
+# See https://errorprone.info/docs/installation and the "As a library" note in
+# https://github.com/google/google-java-format
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=768m \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
 # Build cache can be disabled with --no-build-cache option
 org.gradle.caching=true
 #org.gradle.caching.debug=true


### PR DESCRIPTION
## Why

On JDK 16+, both google-java-format (run by autostyle's `removeUnusedImports`) and Error Prone reach into `jdk.compiler` internals that strong encapsulation no longer exports. autostyle runs google-java-format inside the Gradle daemon and reflectively opens some `com.sun.tools.javac.*` packages. That partial opening defeats the `net.ltgt.errorprone` plugin's auto-fork heuristic (`StrongEncapsulationHelper.needsForking()`), so Error Prone runs in-process in the daemon instead of in a forked compiler that would carry the flags — and crashes with `IllegalAccessError` because `com.sun.tools.javac.model` is still not exported.

The bug is latent: `:cli:compileJava` and `:web:compileJava` are served from the Gradle build cache on `main`, so Error Prone never actually runs. Any change to those modules' compile classpath invalidates the cache and surfaces the crash — for example the `ch.qos.logback:logback-core` bump in #732, which fails every run with:

```
java.lang.IllegalAccessError: class com.google.errorprone.bugpatterns.ASTHelpersSuggestions
  cannot access class com.sun.tools.javac.model.JavacElements ...
  because module jdk.compiler does not export com.sun.tools.javac.model to unnamed module
```

Forcing `options.fork = true` does not help: when the compile toolchain matches the Gradle JVM, Gradle compiles in-process and ignores `forkOptions`.

## What

Add Error Prone's canonical JDK 16+ module flags to `org.gradle.jvmargs` — 8 `--add-exports` and 2 `--add-opens`, a superset of google-java-format's set. With the daemon carrying the full set, in-process compilation succeeds and the errorprone plugin stays happy.

This ports commit 3fa1dfc1 from the `renovate/com.github.autostyle-…-4.x` branch, where it was introduced, onto `main` so the fix is in place independent of the autostyle bump.

## How to verify

On JDK 21:

```
./gradlew :cli:compileJava :web:compileJava --rerun-tasks --no-build-cache
```

Fails on `main`; passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)