### PR TITLE
build: add toolchain directive to go.mod files

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,6 +2,8 @@ module github.com/Netcracker/qubership-profiler-backend
 
 go 1.25.0
 
+toolchain go1.26.4
+
 require (
 	github.com/IBM/pgxpoolprometheus v1.1.3
 	github.com/glebarez/sqlite v1.11.0

--- a/backend/tools/load-generator/go-metrics/go.mod
+++ b/backend/tools/load-generator/go-metrics/go.mod
@@ -55,3 +55,5 @@ require (
 )
 
 go 1.25.0
+
+toolchain go1.26.4

--- a/diagtools/go.mod
+++ b/diagtools/go.mod
@@ -2,6 +2,8 @@ module github.com/Netcracker/qubership-profiler-agent/diagtools
 
 go 1.25.8
 
+toolchain go1.26.4
+
 require (
 	github.com/go-zookeeper/zk v1.0.4
 	github.com/hashicorp/consul/api v1.33.7


### PR DESCRIPTION
## Why

The `release`, `CI`, and `backend-build` workflows read the Go version from go.mod via `go-version-file`. Without a `toolchain` directive, that resolves to the exact patch in the `go` directive (for example `go 1.25.0`), which Renovate never bumps because the `go` directive uses `go-mod-directive` versioning. Builds and releases therefore stay pinned to an outdated Go patch and miss runtime and standard-library security fixes.

## What

Add `toolchain go1.26.4` to all three modules:

- `backend/go.mod`
- `diagtools/go.mod`
- `backend/tools/load-generator/go-metrics/go.mod`

The `go` directive still declares the minimum supported Go version; `toolchain` selects the version used to build. `actions/setup-go` prefers `toolchain` over `go` when both are present, so CI builds with Go 1.26.4 without any workflow change.

## How to verify

- `go build ./...` in `diagtools` passes with the toolchain directive (checked locally with Go 1.26.4).
- `actions/setup-go` with `go-version-file` installs the `toolchain` version rather than the `go` directive.

## Renovate

No config change is needed. Renovate updates the `toolchain` directive by default (golang-version datasource, semver), and the existing "Go" package rule already matches it (`packageName: go`, `datasource: golang-version`). Future bumps arrive in the same grouped PR as the `golang` image and `setup-go` updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)