### PR TITLE
fix(examples): keep /health fast when FAST_HEALTH_ENDPOINT is set

### DIFF
--- a/backend/examples/quarkus-2-vertx/src/main/java/com/netcracker/monitoring/metrics/Helper.java
+++ b/backend/examples/quarkus-2-vertx/src/main/java/com/netcracker/monitoring/metrics/Helper.java
@@ -121,9 +121,21 @@ public class Helper { // framework-agnostic helper. MUST be same in all subproje
         return Collections.singletonMap("status", "Out of service");
     }
 
+    // Environment variable that switches /health to a fast path. When set (to anything but
+    // "false"/"0"), getStatus() skips the emulated CPU load so /health works as a readiness probe.
+    // Leave it unset to reproduce the deliberately slow application the profiler demos exercise.
+    static final String FAST_HEALTH_ENDPOINT_ENV = "FAST_HEALTH_ENDPOINT";
+
+    static boolean fastHealthEndpoint() {
+        String value = System.getenv(FAST_HEALTH_ENDPOINT_ENV);
+        return value != null && !value.equalsIgnoreCase("false") && !value.equals("0");
+    }
+
     public Map<String, String> getStatus() {
-        tooLoong();
-        sleep();
+        if (!fastHealthEndpoint()) {
+            tooLoong();
+            sleep();
+        }
         this.metrics.timer.record((long) (100 * Math.random()), TimeUnit.MILLISECONDS);
         return Collections.singletonMap("status", this.state.recentStatus);
     }

--- a/backend/examples/quarkus-3-vertx-resteasy/src/main/java/com/netcracker/monitoring/metrics/Helper.java
+++ b/backend/examples/quarkus-3-vertx-resteasy/src/main/java/com/netcracker/monitoring/metrics/Helper.java
@@ -121,9 +121,21 @@ public class Helper { // framework-agnostic helper. MUST be same in all subproje
         return Collections.singletonMap("status", "Out of service");
     }
 
+    // Environment variable that switches /health to a fast path. When set (to anything but
+    // "false"/"0"), getStatus() skips the emulated CPU load so /health works as a readiness probe.
+    // Leave it unset to reproduce the deliberately slow application the profiler demos exercise.
+    static final String FAST_HEALTH_ENDPOINT_ENV = "FAST_HEALTH_ENDPOINT";
+
+    static boolean fastHealthEndpoint() {
+        String value = System.getenv(FAST_HEALTH_ENDPOINT_ENV);
+        return value != null && !value.equalsIgnoreCase("false") && !value.equals("0");
+    }
+
     public Map<String, String> getStatus() {
-        tooLoong();
-        sleep();
+        if (!fastHealthEndpoint()) {
+            tooLoong();
+            sleep();
+        }
         this.metrics.timer.record((long) (100 * Math.random()), TimeUnit.MILLISECONDS);
         return Collections.singletonMap("status", this.state.recentStatus);
     }

--- a/backend/examples/quarkus-3-vertx/src/main/java/com/netcracker/monitoring/metrics/Helper.java
+++ b/backend/examples/quarkus-3-vertx/src/main/java/com/netcracker/monitoring/metrics/Helper.java
@@ -121,9 +121,21 @@ public class Helper { // framework-agnostic helper. MUST be same in all subproje
         return Collections.singletonMap("status", "Out of service");
     }
 
+    // Environment variable that switches /health to a fast path. When set (to anything but
+    // "false"/"0"), getStatus() skips the emulated CPU load so /health works as a readiness probe.
+    // Leave it unset to reproduce the deliberately slow application the profiler demos exercise.
+    static final String FAST_HEALTH_ENDPOINT_ENV = "FAST_HEALTH_ENDPOINT";
+
+    static boolean fastHealthEndpoint() {
+        String value = System.getenv(FAST_HEALTH_ENDPOINT_ENV);
+        return value != null && !value.equalsIgnoreCase("false") && !value.equals("0");
+    }
+
     public Map<String, String> getStatus() {
-        tooLoong();
-        sleep();
+        if (!fastHealthEndpoint()) {
+            tooLoong();
+            sleep();
+        }
         this.metrics.timer.record((long) (100 * Math.random()), TimeUnit.MILLISECONDS);
         return Collections.singletonMap("status", this.state.recentStatus);
     }

--- a/backend/examples/spring-boot-2-jetty/src/main/java/com/netcracker/monitoring/metrics/Helper.java
+++ b/backend/examples/spring-boot-2-jetty/src/main/java/com/netcracker/monitoring/metrics/Helper.java
@@ -121,9 +121,21 @@ public class Helper { // framework-agnostic helper. MUST be same in all subproje
         return Collections.singletonMap("status", "Out of service");
     }
 
+    // Environment variable that switches /health to a fast path. When set (to anything but
+    // "false"/"0"), getStatus() skips the emulated CPU load so /health works as a readiness probe.
+    // Leave it unset to reproduce the deliberately slow application the profiler demos exercise.
+    static final String FAST_HEALTH_ENDPOINT_ENV = "FAST_HEALTH_ENDPOINT";
+
+    static boolean fastHealthEndpoint() {
+        String value = System.getenv(FAST_HEALTH_ENDPOINT_ENV);
+        return value != null && !value.equalsIgnoreCase("false") && !value.equals("0");
+    }
+
     public Map<String, String> getStatus() {
-        tooLoong();
-        sleep();
+        if (!fastHealthEndpoint()) {
+            tooLoong();
+            sleep();
+        }
         this.metrics.timer.record((long) (100 * Math.random()), TimeUnit.MILLISECONDS);
         return Collections.singletonMap("status", this.state.recentStatus);
     }

--- a/backend/examples/spring-boot-2-tomcat/src/main/java/com/netcracker/monitoring/metrics/Helper.java
+++ b/backend/examples/spring-boot-2-tomcat/src/main/java/com/netcracker/monitoring/metrics/Helper.java
@@ -121,9 +121,21 @@ public class Helper { // framework-agnostic helper. MUST be same in all subproje
         return Collections.singletonMap("status", "Out of service");
     }
 
+    // Environment variable that switches /health to a fast path. When set (to anything but
+    // "false"/"0"), getStatus() skips the emulated CPU load so /health works as a readiness probe.
+    // Leave it unset to reproduce the deliberately slow application the profiler demos exercise.
+    static final String FAST_HEALTH_ENDPOINT_ENV = "FAST_HEALTH_ENDPOINT";
+
+    static boolean fastHealthEndpoint() {
+        String value = System.getenv(FAST_HEALTH_ENDPOINT_ENV);
+        return value != null && !value.equalsIgnoreCase("false") && !value.equals("0");
+    }
+
     public Map<String, String> getStatus() {
-        tooLoong();
-        sleep();
+        if (!fastHealthEndpoint()) {
+            tooLoong();
+            sleep();
+        }
         this.metrics.timer.record((long) (100 * Math.random()), TimeUnit.MILLISECONDS);
         return Collections.singletonMap("status", this.state.recentStatus);
     }

--- a/backend/examples/spring-boot-2-undertow/src/main/java/com/netcracker/monitoring/metrics/Helper.java
+++ b/backend/examples/spring-boot-2-undertow/src/main/java/com/netcracker/monitoring/metrics/Helper.java
@@ -121,9 +121,21 @@ public class Helper { // framework-agnostic helper. MUST be same in all subproje
         return Collections.singletonMap("status", "Out of service");
     }
 
+    // Environment variable that switches /health to a fast path. When set (to anything but
+    // "false"/"0"), getStatus() skips the emulated CPU load so /health works as a readiness probe.
+    // Leave it unset to reproduce the deliberately slow application the profiler demos exercise.
+    static final String FAST_HEALTH_ENDPOINT_ENV = "FAST_HEALTH_ENDPOINT";
+
+    static boolean fastHealthEndpoint() {
+        String value = System.getenv(FAST_HEALTH_ENDPOINT_ENV);
+        return value != null && !value.equalsIgnoreCase("false") && !value.equals("0");
+    }
+
     public Map<String, String> getStatus() {
-        tooLoong();
-        sleep();
+        if (!fastHealthEndpoint()) {
+            tooLoong();
+            sleep();
+        }
         this.metrics.timer.record((long) (100 * Math.random()), TimeUnit.MILLISECONDS);
         return Collections.singletonMap("status", this.state.recentStatus);
     }

--- a/backend/examples/spring-boot-3-jetty/src/main/java/com/netcracker/monitoring/metrics/Helper.java
+++ b/backend/examples/spring-boot-3-jetty/src/main/java/com/netcracker/monitoring/metrics/Helper.java
@@ -121,9 +121,21 @@ public class Helper { // framework-agnostic helper. MUST be same in all subproje
         return Collections.singletonMap("status", "Out of service");
     }
 
+    // Environment variable that switches /health to a fast path. When set (to anything but
+    // "false"/"0"), getStatus() skips the emulated CPU load so /health works as a readiness probe.
+    // Leave it unset to reproduce the deliberately slow application the profiler demos exercise.
+    static final String FAST_HEALTH_ENDPOINT_ENV = "FAST_HEALTH_ENDPOINT";
+
+    static boolean fastHealthEndpoint() {
+        String value = System.getenv(FAST_HEALTH_ENDPOINT_ENV);
+        return value != null && !value.equalsIgnoreCase("false") && !value.equals("0");
+    }
+
     public Map<String, String> getStatus() {
-        tooLoong();
-        sleep();
+        if (!fastHealthEndpoint()) {
+            tooLoong();
+            sleep();
+        }
         this.metrics.timer.record((long) (100 * Math.random()), TimeUnit.MILLISECONDS);
         return Collections.singletonMap("status", this.state.recentStatus);
     }

--- a/backend/examples/spring-boot-3-tomcat/src/main/java/com/netcracker/monitoring/metrics/Helper.java
+++ b/backend/examples/spring-boot-3-tomcat/src/main/java/com/netcracker/monitoring/metrics/Helper.java
@@ -121,9 +121,21 @@ public class Helper { // framework-agnostic helper. MUST be same in all subproje
         return Collections.singletonMap("status", "Out of service");
     }
 
+    // Environment variable that switches /health to a fast path. When set (to anything but
+    // "false"/"0"), getStatus() skips the emulated CPU load so /health works as a readiness probe.
+    // Leave it unset to reproduce the deliberately slow application the profiler demos exercise.
+    static final String FAST_HEALTH_ENDPOINT_ENV = "FAST_HEALTH_ENDPOINT";
+
+    static boolean fastHealthEndpoint() {
+        String value = System.getenv(FAST_HEALTH_ENDPOINT_ENV);
+        return value != null && !value.equalsIgnoreCase("false") && !value.equals("0");
+    }
+
     public Map<String, String> getStatus() {
-        tooLoong();
-        sleep();
+        if (!fastHealthEndpoint()) {
+            tooLoong();
+            sleep();
+        }
         this.metrics.timer.record((long) (100 * Math.random()), TimeUnit.MILLISECONDS);
         return Collections.singletonMap("status", this.state.recentStatus);
     }

--- a/backend/examples/spring-boot-3-undertow/src/main/java/com/netcracker/monitoring/metrics/Helper.java
+++ b/backend/examples/spring-boot-3-undertow/src/main/java/com/netcracker/monitoring/metrics/Helper.java
@@ -121,9 +121,21 @@ public class Helper { // framework-agnostic helper. MUST be same in all subproje
         return Collections.singletonMap("status", "Out of service");
     }
 
+    // Environment variable that switches /health to a fast path. When set (to anything but
+    // "false"/"0"), getStatus() skips the emulated CPU load so /health works as a readiness probe.
+    // Leave it unset to reproduce the deliberately slow application the profiler demos exercise.
+    static final String FAST_HEALTH_ENDPOINT_ENV = "FAST_HEALTH_ENDPOINT";
+
+    static boolean fastHealthEndpoint() {
+        String value = System.getenv(FAST_HEALTH_ENDPOINT_ENV);
+        return value != null && !value.equalsIgnoreCase("false") && !value.equals("0");
+    }
+
     public Map<String, String> getStatus() {
-        tooLoong();
-        sleep();
+        if (!fastHealthEndpoint()) {
+            tooLoong();
+            sleep();
+        }
         this.metrics.timer.record((long) (100 * Math.random()), TimeUnit.MILLISECONDS);
         return Collections.singletonMap("status", this.state.recentStatus);
     }

--- a/sample-apps/it-spring-boot-3/src/test/kotlin/com/netcracker/profiler/test/spring/HttpServletRequestAdapterSpringSessionTest.kt
+++ b/sample-apps/it-spring-boot-3/src/test/kotlin/com/netcracker/profiler/test/spring/HttpServletRequestAdapterSpringSessionTest.kt
@@ -58,6 +58,9 @@ class HttpServletRequestAdapterSpringSessionTest {
                     .copy("app.jar", "/app/app.jar")
                     .copy("agent-logback.xml", "/app/agent-logback.xml")
                     .env("NC_DIAGNOSTIC_MODE", "prod")
+                    // Serve /health without the emulated CPU load, so it works as a readiness probe.
+                    // Unset, the demo app deliberately busy-waits on /health (see Helper.getStatus).
+                    .env("FAST_HEALTH_ENDPOINT", "true")
                     .expose(8080)
                     .cmd(
                         "java",


### PR DESCRIPTION
## Why

`HttpServletRequestAdapterSpringSessionTest` (`:sample-apps:it-spring-boot-3:test`) flakes in CI with a Testcontainers timeout: `Timed out waiting for URL to be accessible (http://localhost:.../health should return HTTP [200])` → `SocketTimeoutException: Read timed out`.

The container log shows the app itself starts fine (`Started TestApplication in 2.709 seconds`). The problem is the endpoint the wait strategy probes. The demo app deliberately busy-waits in `Helper.getStatus()` — `tooLoong()` spins the CPU for up to 5 seconds per call — so the profiler has interesting call trees to capture. Each health probe therefore read-times-out (~1s) long before `getStatus()` returns, and the container start gives up after 120s. Under CI load (the same job runs several heavy agent tests in parallel), this fails often enough to break unrelated PRs.

## What

Gate the emulated load behind a new `FAST_HEALTH_ENDPOINT` environment variable:

- Unset (default): unchanged — `/health` stays deliberately slow, so the demo still reproduces the production-like, loaded application.
- Set (to anything but `false`/`0`): `getStatus()` skips `tooLoong()`/`sleep()` and returns immediately, so `/health` works as a readiness probe.

The integration test now sets `FAST_HEALTH_ENDPOINT=true` on the container. The change is applied to all nine `backend/examples/*/Helper.java` copies to keep them in sync.

The always-on background loops (`HistogramService.process` every 2s, `MetricsController.callRandomEndpoint` every 10s) are left untouched — the fix is scoped to `/health`, and a fast `getStatus()` responds within the probe read timeout even with those loops running.

## How to verify

- `mvn package -DskipTests -q` in `backend/examples/spring-boot-3-undertow` builds cleanly (the added code needs no new imports).
- Re-run `:sample-apps:it-spring-boot-3:test`; `/health` now returns 200 promptly and the container starts.

## Note for reviewers

`backend/` is a git subtree imported from a separate upstream repository, so the `backend/examples/**/Helper.java` edits here should also land in that source repository; otherwise a future subtree pull may overwrite them. The `sample-apps/` test change is native to this repository.
