### PR TITLE
feat(backend): build the profiler-backend image and ship its chart

### DIFF
--- a/backend/.qubership/docker-build-config.cfg
+++ b/backend/.qubership/docker-build-config.cfg
@@ -6,6 +6,11 @@
       "context": "backend"
     },
     {
+      "name": "qubership-profiler-backend",
+      "file": "backend/apps/profiler-backend/Dockerfile",
+      "context": "backend"
+    },
+    {
       "name": "qubership-profiler-transfer",
       "file": "backend/docker-transfer/Dockerfile",
       "context": "backend"

--- a/backend/docker-transfer/Dockerfile
+++ b/backend/docker-transfer/Dockerfile
@@ -1,7 +1,8 @@
 FROM scratch
 ARG USER_UID=1000
 
-# Helm charts for dumps-collector deployment
+# Helm charts shipped for deployment
 COPY charts/dumps-collector /charts/dumps-collector
+COPY charts/profiler-backend /charts/profiler-backend
 
 USER ${USER_UID}


### PR DESCRIPTION
## Why

The Go `profiler-backend` (with the UI embedded via `go:embed`) and its Helm chart `backend/charts/profiler-backend` already exist, but nothing publishes them. Both the release and the dev Docker workflows fan out over the components in `backend/.qubership/docker-build-config.cfg`, and that file lists only `qubership-profiler-dumps-collector` and the `qubership-profiler-transfer` chart-carrier. So `profiler-backend` is never built or pushed, and its chart never ships because the transfer image copies only `charts/dumps-collector`.

## What

- Add the `qubership-profiler-backend` component to `backend/.qubership/docker-build-config.cfg`, pointing at `backend/apps/profiler-backend/Dockerfile` with `context: backend`. Both `release.yaml` and `backend-dev-docker-build.yml` read this config, so the image now builds and pushes in both flows. The UI ships inside this image, so no separate UI component is needed.
- Copy `charts/profiler-backend` into `backend/docker-transfer/Dockerfile` so the chart rides along in the already-released transfer image.

This mirrors, in reverse, how the legacy removal in d5d9375 dropped a component and one `COPY charts/...` line.

## How to verify

- `jq` schema check on the config passes and every referenced Dockerfile exists.
- `docker build -f backend/docker-transfer/Dockerfile backend` builds; the transfer image carries the full `charts/profiler-backend` tree (28 files) alongside `charts/dumps-collector`.
- `cd backend && make helm-lint` — `helm lint` clean, kubeconform valid.
- The PR run of `backend-dev-docker-build.yml` builds every component with `dry-run: true` (no publish), exercising the profiler-backend image build end to end.

## Out of scope

`backend/charts/profiler-backend/values.yaml` keeps `repository: profiler-backend` / `tag: dev` as a deliberate local/smoke default. Aligning the chart default with the published `ghcr.io/netcracker/qubership-profiler-backend:<version>` is a deployment concern, left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)