### PR TITLE
fix(profiler): harden fast-purge floor walk and pending-parquet recheck

### DIFF
--- a/backend/libs/collector/hotstore/janitor.go
+++ b/backend/libs/collector/hotstore/janitor.go
@@ -466,9 +466,12 @@ func (s *Store) bucketHasUnsealedCalls(bucket int64) (bool, error) {
 // purge materializes the rows' method names into method_text; trace reads of
 // those rows fall through to the cold tier exactly as after a mem-budget
 // chunk-index release. Deleting the segments under the still-indexed rows is
-// safe because the two gates above already ran: no pending parquet means every
+// safe because fastPurge re-confirms both gates in the race-free order (no
+// unsealed calls, then no pending parquet): no pending parquet means every
 // sealed file is confirmed in S3 and MarkUploaded released its segment
-// refcounts, and no unsealed calls means no future seal will read them.
+// refcounts, and no unsealed calls means no future seal will read them. The
+// early HasPendingParquet gate below is a fast reject; fastPurge's recheck is
+// the authoritative one for the fast path (a seal can commit in between).
 func (s *Store) purgeWals(ctx context.Context, nowMs int64, stats *JanitorStats) error {
 	candidates, err := s.db.WalPurgeCandidates()
 	if err != nil {
@@ -543,9 +546,11 @@ func (s *Store) purgeWals(ctx context.Context, nowMs int64, stats *JanitorStats)
 
 // fastPurge decides the 03 §3.9 fast path for one still-indexed candidate and
 // prepares its rows: eligible when the fast path is enabled, the pod-restart's
-// directory is at or under the near-empty floor, and every indexed call is
-// sealed (an in-flight seal pass keeps its watermark uncommitted, so
-// HasUnsealedCalls also defers to the next janitor tick). On eligibility it
+// directory is at or under the near-empty floor, every indexed call is sealed
+// (an in-flight seal pass keeps its watermark uncommitted, so HasUnsealedCalls
+// defers to the next janitor tick), and no pending parquet remains — rechecked
+// here, after HasUnsealedCalls, to close the seal-commit race described in
+// purgeWals. On eligibility it
 // backfills method_text — committed to the partitions BEFORE the caller
 // deletes the dictionary WAL, so a crashed purge re-runs as a no-op.
 func (s *Store) fastPurge(ctx context.Context, key PodRestartKey, podRestart, dir string) (bool, error) {
@@ -560,6 +565,21 @@ func (s *Store) fastPurge(ctx context.Context, key PodRestartKey, podRestart, di
 		return false, nil
 	}
 	if unsealed, err := s.db.HasUnsealedCalls(podRestart); err != nil || unsealed {
+		return false, err
+	}
+	// Re-check the pending-parquet gate AFTER confirming no unsealed calls, and
+	// after the early HasPendingParquet gate in purgeWals. CommitSealPass inserts
+	// the pending parquet_local row and advances the seal watermark in one
+	// transaction, so a seal pass that commits between purgeWals's early gate and
+	// this point leaves HasUnsealedCalls false yet a live pending file behind. The
+	// early gate alone would then read stale ("no pending") and delete calls.wal
+	// under a file still owed to S3; if that file were later lost, its re-seal
+	// (RecoverLostPendingParquet rewinds the watermark) would find no calls.wal to
+	// rebuild from — permanent loss. Reading unsealed first and pending second
+	// closes the window: unsealed false means the seal already committed, so its
+	// pending row is visible here. A closed pod-restart gains no new calls, so
+	// unsealed stays false and this recheck is stable.
+	if pending, err := s.db.HasPendingParquet(podRestart); err != nil || pending {
 		return false, err
 	}
 	resolve := func(int) (string, bool) { return "", false }

--- a/backend/libs/collector/hotstore/janitor.go
+++ b/backend/libs/collector/hotstore/janitor.go
@@ -552,11 +552,11 @@ func (s *Store) fastPurge(ctx context.Context, key PodRestartKey, podRestart, di
 	if s.cfg.WalPurgeFastMaxBytes <= 0 {
 		return false, nil
 	}
-	size, err := dirSizeBytes(dir)
+	within, err := dirWithinFloor(dir, s.cfg.WalPurgeFastMaxBytes)
 	if err != nil {
 		return false, err
 	}
-	if size > s.cfg.WalPurgeFastMaxBytes {
+	if !within {
 		return false, nil
 	}
 	if unsealed, err := s.db.HasUnsealedCalls(podRestart); err != nil || unsealed {
@@ -577,9 +577,14 @@ func (s *Store) fastPurge(ctx context.Context, key PodRestartKey, podRestart, di
 	return true, nil
 }
 
-// dirSizeBytes sums the file sizes under dir; a missing dir is zero (a crashed
-// purge already removed it).
-func dirSizeBytes(dir string) (int64, error) {
+// dirWithinFloor reports whether the files under dir sum to floor bytes or
+// fewer. It stops walking the moment the running total crosses floor, so a
+// pod-restart well over the near-empty floor costs a few stat calls instead of
+// a full walk of its (possibly many) segment files — the fast-path floor check
+// runs on every still-indexed candidate each janitor tick. A missing dir sums
+// to zero (a crashed purge already removed it), which reads as within the
+// floor.
+func dirWithinFloor(dir string, floor int64) (bool, error) {
 	var total int64
 	err := filepath.WalkDir(dir, func(_ string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
@@ -587,13 +592,16 @@ func dirSizeBytes(dir string) (int64, error) {
 		}
 		if info, err := d.Info(); err == nil {
 			total += info.Size()
+			if total > floor {
+				return filepath.SkipAll
+			}
 		}
 		return nil
 	})
 	if err != nil && !os.IsNotExist(err) {
-		return 0, errors.Wrapf(err, "measure %s", dir)
+		return false, errors.Wrapf(err, "measure %s", dir)
 	}
-	return total, nil
+	return total <= floor, nil
 }
 
 // removeEmptyParents best-effort removes now-empty pod/service/namespace dirs

--- a/backend/libs/collector/hotstore/janitor_test.go
+++ b/backend/libs/collector/hotstore/janitor_test.go
@@ -299,6 +299,40 @@ func TestFastPurgeGates(t *testing.T) {
 	})
 }
 
+// TestFastPurgeRechecksPendingParquet pins the seal-commit race close: a pending
+// (sealed but not-yet-uploaded) parquet_local row must block the fast path even
+// when HasUnsealedCalls is already false. That is the state a seal pass leaves —
+// CommitSealPass inserts the pending row and advances the watermark atomically —
+// if it commits between purgeWals's early HasPendingParquet gate and fastPurge.
+// Deleting calls.wal here would strand the file's re-seal if the pending file
+// were later lost, so fastPurge rechecks the gate after HasUnsealedCalls.
+func TestFastPurgeRechecksPendingParquet(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(Config{DataDir: t.TempDir(), WalPurgeFastMaxBytes: 1 << 20})
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	key := PodRestartKey{Namespace: "ns", Service: "svc", PodName: "pod-race", RestartTimeMs: janitorCallTs}
+	pr, _ := seedFastPurgeCandidate(t, store, key, "w")
+	bucket := store.cfg.Bucket(janitorCallTs)
+
+	// A second sealed file recorded but not uploaded: the pending row a committed
+	// seal pass leaves behind. Its watermark already covers the one indexed call,
+	// so HasUnsealedCalls stays false and only the pending recheck can catch this.
+	seedSealedFile(t, store, pr.Key, bucket, 1)
+	pending, err := store.db.HasPendingParquet(pr.Key.String())
+	require.NoError(t, err)
+	require.True(t, pending)
+	unsealed, err := store.db.HasUnsealedCalls(pr.Key.String())
+	require.NoError(t, err)
+	require.False(t, unsealed, "the watermark already covers the indexed call")
+
+	ok, err := store.fastPurge(ctx, pr.Key, pr.Key.String(), pr.dir)
+	require.NoError(t, err)
+	assert.False(t, ok, "a live pending parquet must defer the fast purge")
+	assert.FileExists(t, filepath.Join(pr.dir, "dictionary.wal"), "the WAL set survives while an upload is owed")
+}
+
 // TestFastPurgeCrashRetryConverges pins the step-18a idempotence: a purge that
 // crashed after the backfill and the WAL deletion but before SetWalsPurged
 // re-runs to completion — the size check reads a missing directory as zero,


### PR DESCRIPTION
## Why

The janitor's `fastPurge` had two problems under a reconnect storm, where many near-empty pod-restarts recur on every tick.

- Every still-indexed candidate paid a full `WalkDir` of its directory just to compare its size against the near-empty floor, even when it sat far over the floor and could never qualify.
- `purgeWals` read the `HasPendingParquet` gate early but `HasUnsealedCalls` late. A seal pass committing between the two reads (`CommitSealPass` inserts the pending row and advances the watermark in one transaction) left the early gate stale, so `fastPurge` could drop `calls.wal` while a file was still owed to S3. Losing that file would then strand `RecoverLostPendingParquet` with no WAL to rebuild from — permanent loss plus a poisoned bucket that blocks the partition drop.

## What

- Replace `dirSizeBytes` with `dirWithinFloor`, which stops the walk via `filepath.SkipAll` once the running total crosses the floor. An over-floor candidate now costs a few stat calls; the near-empty case is unchanged. A missing directory still reads as within the floor.
- Recheck `HasPendingParquet` inside `fastPurge`, after `HasUnsealedCalls`. Reading unsealed first and pending second closes the race: an unsealed-false result means the seal already committed, so its pending row is visible on the second read.

## How to verify

```
cd backend && go test ./libs/collector/hotstore/
```

New coverage in `janitor_test.go` exercises the seal-commits-mid-purge window.
