### PR TITLE
fix(profiler): sweep orphan quarantined parquet in recovery

### DIFF
--- a/backend/libs/collector/hotstore/recovery.go
+++ b/backend/libs/collector/hotstore/recovery.go
@@ -177,19 +177,48 @@ func (s *Store) reconcileParquetLocal(ctx context.Context) error {
 			return err
 		}
 	}
-	sealedRoot := filepath.Join(s.cfg.DataDir, "parquet")
-	err = filepath.WalkDir(sealedRoot, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".parquet") {
-			return nil //nolint:nilerr // a missing root means nothing sealed yet
+	// A crash before the seal commit leaves a footer-less parquet under parquet/
+	// with no catalog row; a rename→DB double fault in quarantine() (issue #824)
+	// leaves the mirror case under upload-failed/ — the file moved but
+	// MarkUploadFailed never committed, so the row still points at the old
+	// parquet/ path (reconciled above as a lost pending file) and nothing owns
+	// the moved copy. Neither the quarantine cap nor the upload loop walks a
+	// file without a row, so recovery is the only sweep that reclaims it. Both
+	// roots share the same rule: a .parquet file catalogued by no parquet_local
+	// row is an orphan.
+	if err := s.sweepUncataloguedParquet(ctx, filepath.Join(s.cfg.DataDir, "parquet"), catalogued,
+		"sealed parquet %s has no catalog row (crash before the seal commit); removing the orphan"); err != nil {
+		return err
+	}
+	if err := s.sweepUncataloguedParquet(ctx, filepath.Join(s.cfg.DataDir, "upload-failed"), catalogued,
+		"quarantined parquet %s has no catalog row (rename→DB double fault, issue #824); removing the orphan"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// sweepUncataloguedParquet removes every .parquet file under root whose path is
+// not in catalogued (the set of live parquet_local paths). The quarantined
+// manifest and snapshot bodies that also live under upload-failed/ carry
+// non-parquet suffixes, so the suffix filter leaves them untouched.
+func (s *Store) sweepUncataloguedParquet(ctx context.Context, root string, catalogued map[string]struct{}, logMsg string) error {
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err // propagate; a missing root is suppressed after WalkDir
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".parquet") {
+			return nil
 		}
 		if _, ok := catalogued[path]; ok {
 			return nil
 		}
-		log.Warning(ctx, "sealed parquet %s has no catalog row (crash before the seal commit); removing the orphan", path)
+		log.Warning(ctx, logMsg, path)
 		return os.Remove(path)
 	})
 	if err != nil && !os.IsNotExist(err) {
-		return errors.Wrap(err, "sweep orphan sealed parquet")
+		// A missing root means nothing sealed yet; any other traversal failure
+		// left orphans behind, so fail recovery rather than report a clean sweep.
+		return errors.Wrap(err, "sweep orphan parquet")
 	}
 	return nil
 }

--- a/backend/libs/collector/hotstore/recovery_test.go
+++ b/backend/libs/collector/hotstore/recovery_test.go
@@ -110,6 +110,52 @@ func TestRecoverRemovesOrphanSealedParquet(t *testing.T) {
 	assert.NoFileExists(t, orphan, "an uncommitted seal's file is swept")
 }
 
+// TestRecoverSweepsOrphanQuarantinedParquet pins issue #824: quarantine() renames
+// a rejected parquet into upload-failed/ before it records the move, so a rename
+// that succeeds followed by a MarkUploadFailed that fails leaves the file under
+// upload-failed/ with no owning parquet_local row. The quarantine cap and the
+// upload loop both walk rows only, so nothing but recovery can reclaim it.
+// Recovery sweeps upload-failed/ the same way it sweeps parquet/: a .parquet file
+// catalogued by no row is removed, while a legitimately quarantined file — one
+// whose row points at its upload-failed/ path — survives.
+func TestRecoverSweepsOrphanQuarantinedParquet(t *testing.T) {
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	store, err := Open(Config{DataDir: dataDir})
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	key := PodRestartKey{Namespace: "ns", Service: "svc", PodName: "pod-q", RestartTimeMs: 1_000}
+	require.NoError(t, store.db.UpsertPodRestart(key, 1_000))
+
+	uploadFailedDir := filepath.Join(dataDir, "upload-failed")
+	seed := func(s3Key string) string {
+		path := filepath.Join(uploadFailedDir, filepath.FromSlash(s3Key))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("parquet"), 0o644))
+		return path
+	}
+
+	// The double-fault orphan: the file moved but MarkUploadFailed never
+	// committed, so no row owns it.
+	orphan := seed("parquet/v1/short_clean/2023/11/14/22/collector-0-bbbb-x-x-x-0.parquet")
+
+	// A legitimately quarantined file: its row points at the upload-failed/ path,
+	// so the sweep must spare it.
+	quarantined := seed("parquet/v1/short_clean/2023/11/14/22/collector-0-aaaa-x-x-x-0.parquet")
+	require.NoError(t, store.db.RecordSealedFile(parquetLocalRow{
+		Path: quarantined, PodRestart: key.String(), TimeBucketMs: 0,
+		RetentionClass: RetentionShortClean, Seq: 0, RowCount: 1,
+		TimeMinMs: 1, TimeMaxMs: 2, FileSize: 7, SealedAtMs: 1,
+		S3Key: "parquet/v1/short_clean/x/a.parquet",
+	}, nil))
+	require.NoError(t, store.db.MarkUploadFailed(quarantined, quarantined, 1))
+
+	require.NoError(t, store.Recover(ctx))
+	assert.NoFileExists(t, orphan, "an orphan with no parquet_local row is swept")
+	assert.FileExists(t, quarantined, "a legitimately quarantined file keeps its row and survives")
+}
+
 // TestRecoverReSealsLostPendingParquet pins the QA 708#2 fix: a pending (not yet
 // uploaded) sealed file whose local copy vanished before it reached S3 must not
 // be silently forgotten. Recovery rewinds the bucket's seal watermark to the


### PR DESCRIPTION
## Why

Closes #824.

`quarantine()` renames a rejected parquet into `upload-failed/` before it records the move in SQLite. When the rename succeeds and `MarkUploadFailed` then fails — an S3 permanent rejection (4xx) and a SQLite failure on the same file, in that order — the file outlives its `parquet_local` row. Recovery heals the row (it rewinds the seal watermark and re-seals a replacement), but the moved copy under `upload-failed/` has no owning row, and nothing reclaims it: `capQuarantine` walks `QuarantinedParquet()` rows only, and the recovery orphan sweep covered `parquet/` but not `upload-failed/`. The file leaked until an operator cleared it by hand.

## What

Extract the recovery orphan sweep into `sweepUncataloguedParquet` and run it over `upload-failed/` as well as `parquet/`: a `.parquet` file catalogued by no `parquet_local` row is removed. The suffix filter spares the quarantined manifest and snapshot bodies that also live under `upload-failed/`, and a legitimately quarantined file — its row points at the `upload-failed/` path — survives.

The extracted helper also fixes a latent defect the `parquet/` sweep already had: the `WalkDir` callback swallowed traversal errors into `nil`, so a permission or I/O error on a subtree reported a clean sweep while leaving orphans behind. The callback now propagates the error, and only the missing-root case (`os.IsNotExist`) is suppressed after `WalkDir`, matching the intent the post-walk guard already expressed.

Reordering `quarantine()` to DB-first is not the fix: it only moves the orphan back under `parquet/`, where the existing sweep already catches it, so a dedicated `upload-failed/` sweep is the smaller, complete change.

## How to verify

`go test ./libs/collector/hotstore/` — the new `TestRecoverSweepsOrphanQuarantinedParquet` seeds one orphan (a file under `upload-failed/` with no row) alongside a legitimately quarantined file (row points at its `upload-failed/` path), runs `Recover`, and asserts the orphan is swept while the quarantined file survives.

Reviewed with an automatic Codex pass (two iterations, final review clean).