### PR TITLE
fix(profiler): move query /metrics and pprof off the external port

### DIFF
--- a/backend/apps/profiler-backend/README.md
+++ b/backend/apps/profiler-backend/README.md
@@ -14,9 +14,11 @@ states, and the process wiring.
 `all` (`03-lifecycle.md` §9) is not implemented yet.
 
 Every subcommand serves Prometheus `/metrics`: `collect` on the internal port
-(scrapable through LOADING/RECOVERY), `query` on the external port, `maintain`
-on `PROFILER_METRICS_PORT` in loop mode (`--run-now` exits too fast to
-scrape). The series names are a stable contract — the catalog lives in
+(scrapable through LOADING/RECOVERY), `query` and `maintain` on a dedicated
+metrics port (`PROFILER_METRICS_PORT`; `maintain` binds it only in loop mode,
+since `--run-now` exits too fast to scrape). query keeps `/metrics` and
+`/debug/pprof` off its external port so the ingress cannot reach them
+(reports2#15). The series names are a stable contract — the catalog lives in
 `charts/profiler-backend/README.md`.
 
 ## Quick start (docker-compose)
@@ -73,7 +75,8 @@ Not wired yet (their features belong to later Stage 1 tasks):
 
 | Env | Default | Description |
 |---|---|---|
-| `PROFILER_EXTERNAL_API_PORT` | `8080` | `/api/v1` and the health probes. |
+| `PROFILER_EXTERNAL_API_PORT` | `8080` | `/api/v1`, the UI, and the health probes. |
+| `PROFILER_METRICS_PORT` | `8081` | Separate listener for `/metrics` and `/debug/pprof`, off the external port so the ingress cannot reach them. |
 | `COLLECTOR_HEADLESS_SVC` | — | Headless-Service DNS name for replica discovery; empty serves the cold tier only. |
 | `PROFILER_INTERNAL_API_PORT` | `8081` | The replicas' internal API port. |
 | `PROFILER_OVERLAP_MARGIN` | `5m` | Hot/cold overlap window. |

--- a/backend/apps/profiler-backend/cmd/query.go
+++ b/backend/apps/profiler-backend/cmd/query.go
@@ -46,10 +46,11 @@ func runQuery(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Bind the external port and gate before S3 (rather than after, as
+	// Bind both listeners and the gate before S3 (rather than after, as
 	// before): a probe must see LOADING instead of connection-refused while
 	// S3 is still coming up (PR 708 review #22), the same reasoning as the
-	// collector's internal port (03-lifecycle.md §2).
+	// collector's internal port (03-lifecycle.md §2). Bind synchronously so a
+	// port collision fails startup at once instead of hiding behind S3 retries.
 	gate := health.NewGate("/api/v1")
 	reg := metrics.NewRegistry()
 	// Expose the cdt_minio_* series (registered on the default registry inside
@@ -59,15 +60,30 @@ func runQuery(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return pkgerrors.Wrap(err, "bind external API")
 	}
-	// query has no internal port, so /metrics rides the external one (04 §12);
-	// the ingress publishes /api/v1 only.
-	external := &http.Server{Handler: metrics.Mux(reg, metrics.InstrumentHTTP(reg, gate), cfg.PprofEnabled)}
-	serveErr := make(chan error, 1)
+	// /metrics and /debug/pprof ride a separate port, off the external listener
+	// the ingress publishes at path / (04 §12), so neither leaks past the
+	// cluster boundary.
+	metricsLn, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.MetricsPort))
+	if err != nil {
+		_ = ln.Close()
+		return pkgerrors.Wrap(err, "bind metrics")
+	}
+	extHandler, metricsHandler := metrics.QueryHandlers(reg, gate, cfg.PprofEnabled)
+	external := &http.Server{Handler: extHandler}
+	metricsSrv := &http.Server{Handler: metricsHandler}
+	serveErr := make(chan error, 2)
 	go func() { serveErr <- external.Serve(ln) }()
+	go func() { serveErr <- metricsSrv.Serve(metricsLn) }()
+
+	// closeServers stops both listeners; safe to call more than once.
+	closeServers := func() {
+		_ = external.Close()
+		_ = metricsSrv.Close()
+	}
 
 	fatal := func(stage string, err error) error {
 		gate.Set(health.StateFatal, stage+": "+err.Error())
-		_ = external.Close()
+		closeServers()
 		return pkgerrors.Wrap(err, stage)
 	}
 
@@ -133,8 +149,8 @@ func runQuery(cmd *cobra.Command, _ []string) error {
 	if len(thresholds) == 0 {
 		thresholds = model.DefaultDurationThresholds()
 	}
-	log.Info(ctx, "query ready: external API :%d, collector service %q, duration thresholds %v",
-		cfg.ExternalAPIPort, cfg.CollectorService, thresholds)
+	log.Info(ctx, "query ready: external API :%d, metrics :%d, collector service %q, duration thresholds %v",
+		cfg.ExternalAPIPort, cfg.MetricsPort, cfg.CollectorService, thresholds)
 
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -155,6 +171,7 @@ func runQuery(cmd *cobra.Command, _ []string) error {
 		shCtx, shCancel := context.WithTimeout(context.Background(), inFlightGrace)
 		defer shCancel()
 		_ = external.Shutdown(shCtx)
+		_ = metricsSrv.Shutdown(shCtx)
 		cancel()
 	})
 	gr.Add(signalActor(runCtx, gate, cfg.ShutdownDrainGrace))

--- a/backend/apps/profiler-backend/pkg/envconfig/envconfig.go
+++ b/backend/apps/profiler-backend/pkg/envconfig/envconfig.go
@@ -106,7 +106,12 @@ type (
 	Query struct {
 		LogLevel string `envconfig:"PROFILER_LOG_LEVEL" default:"info"`
 
-		ExternalAPIPort  int           `envconfig:"PROFILER_EXTERNAL_API_PORT" default:"8080"`
+		ExternalAPIPort int `envconfig:"PROFILER_EXTERNAL_API_PORT" default:"8080"`
+		// MetricsPort serves /metrics and /debug/pprof on a listener separate
+		// from the external API, so the ingress (which maps the external port at
+		// path /) never exposes them (04 §12). It stays off every Service and is
+		// scraped pod-directly by a PodMonitor.
+		MetricsPort      int           `envconfig:"PROFILER_METRICS_PORT" default:"8081"`
 		CollectorService string        `envconfig:"COLLECTOR_HEADLESS_SVC"`
 		CollectorPort    int           `envconfig:"PROFILER_INTERNAL_API_PORT" default:"8081"`
 		OverlapMargin    time.Duration `envconfig:"PROFILER_OVERLAP_MARGIN" default:"5m"`
@@ -129,10 +134,9 @@ type (
 
 		ShutdownDrainGrace time.Duration `envconfig:"PROFILER_SHUTDOWN_DRAIN_GRACE" default:"30s"`
 
-		// PprofEnabled mounts net/http/pprof on the external API port —
-		// query has no internal port (04 §12), so the profiles ride the
-		// same listener as /api/v1. The ingress publishes /api/v1 only, so
-		// /debug/pprof stays cluster-internal; still, default off.
+		// PprofEnabled mounts net/http/pprof on the metrics port (04 §12), so
+		// the profiles never ride the external listener the ingress publishes.
+		// Default off: profiles cost CPU to take.
 		PprofEnabled bool `envconfig:"PROFILER_PPROF_ENABLED"`
 
 		// DumpsCollectorURL is the dumps-collector base URL, e.g.

--- a/backend/apps/profiler-backend/pkg/metrics/metrics.go
+++ b/backend/apps/profiler-backend/pkg/metrics/metrics.go
@@ -49,6 +49,30 @@ func Mux(reg *prometheus.Registry, next http.Handler, withPprof bool) http.Handl
 	return mux
 }
 
+// MetricsMux serves /metrics (and /debug/pprof when withPprof) on a dedicated
+// listener with no fallthrough: an unmatched path answers 404, never an API or
+// UI route. query binds this on its metrics port so the ingress, which maps the
+// external port at path /, cannot reach either surface (04 §12). Unlike Mux, it
+// has no `next` handler and mounts no health gate — a scrape works regardless of
+// service state.
+func MetricsMux(reg *prometheus.Registry, withPprof bool) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", Handler(reg))
+	if withPprof {
+		RegisterPprof(mux)
+	}
+	return mux
+}
+
+// QueryHandlers builds query's two HTTP surfaces. external instruments and
+// serves api (the /api/v1 + UI handler behind the health gate); metricsH serves
+// /metrics and pprof on a separate listener. external never carries /metrics or
+// pprof — that split is what keeps them off the port the ingress publishes at
+// path / (04 §12). Both draw from the same registry.
+func QueryHandlers(reg *prometheus.Registry, api http.Handler, pprofEnabled bool) (external, metricsH http.Handler) {
+	return InstrumentHTTP(reg, api), MetricsMux(reg, pprofEnabled)
+}
+
 // InstrumentHTTP wraps next with the profiler_query_http_request_seconds
 // histogram (code, method). No path label: call PKs in paths would explode
 // the cardinality, and the load dashboards (load-testing-plan.md §6.2) need

--- a/backend/apps/profiler-backend/pkg/metrics/metrics_test.go
+++ b/backend/apps/profiler-backend/pkg/metrics/metrics_test.go
@@ -27,6 +27,76 @@ func TestInstrumentHTTP(t *testing.T) {
 	t.Fatal("profiler_query_http_request_seconds is not registered")
 }
 
+// TestMetricsMux pins the dedicated metrics listener: /metrics serves the
+// registry, pprof is gated by the flag, and nothing else falls through — an
+// unmatched path answers 404 rather than an API or UI route.
+func TestMetricsMux(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		withPprof bool
+		wantPprof int
+	}{
+		{name: "disabled", withPprof: false, wantPprof: http.StatusNotFound},
+		{name: "enabled", withPprof: true, wantPprof: http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := MetricsMux(NewRegistry(), tc.withPprof)
+
+			get := func(path string) (int, string) {
+				rec := httptest.NewRecorder()
+				mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+				return rec.Code, rec.Body.String()
+			}
+
+			code, body := get("/metrics")
+			assert.Equal(t, http.StatusOK, code)
+			assert.Contains(t, body, "# HELP", "/metrics must serve Prometheus exposition")
+
+			pprofCode, _ := get("/debug/pprof/")
+			assert.Equal(t, tc.wantPprof, pprofCode)
+
+			// No fallthrough: an API path is a plain 404, never the registry.
+			apiCode, _ := get("/api/v1/anything")
+			assert.Equal(t, http.StatusNotFound, apiCode)
+		})
+	}
+}
+
+// TestQueryHandlersSplit pins the security contract of the reports2#15 fix: the
+// external surface never exposes /metrics or /debug/pprof, so the ingress that
+// maps the external port at path / cannot reach them (04 §12). Only the metrics
+// listener serves them.
+func TestQueryHandlersSplit(t *testing.T) {
+	reg := NewRegistry()
+	// Stand-in for the gated /api/v1 + UI handler: any non-metrics path lands here.
+	api := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	external, metricsH := QueryHandlers(reg, api, true)
+
+	get := func(h http.Handler, path string) (int, string) {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		return rec.Code, rec.Body.String()
+	}
+
+	// External: /metrics and /debug/pprof fall through to the API stand-in, so
+	// they never carry the Prometheus exposition or the pprof index. Re-adding
+	// Mux to this listener would break both assertions.
+	_, extMetrics := get(external, "/metrics")
+	assert.NotContains(t, extMetrics, "# HELP", "external port must not serve Prometheus exposition")
+	extPprofCode, extPprof := get(external, "/debug/pprof/")
+	assert.Equal(t, http.StatusTeapot, extPprofCode)
+	assert.NotContains(t, extPprof, "Types of profiles available", "external port must not serve pprof")
+
+	// Metrics listener: both surfaces live here.
+	metricsCode, metricsBody := get(metricsH, "/metrics")
+	assert.Equal(t, http.StatusOK, metricsCode)
+	assert.Contains(t, metricsBody, "# HELP")
+	pprofCode, _ := get(metricsH, "/debug/pprof/")
+	assert.Equal(t, http.StatusOK, pprofCode)
+}
+
 // TestMuxPprofGate pins the pprof exposure contract (load-testing-plan.md
 // §6): the profile routes exist only when the flag is on, and turning them on
 // never shadows /metrics or the API fallthrough.

--- a/backend/charts/profiler-backend/README.md
+++ b/backend/charts/profiler-backend/README.md
@@ -78,7 +78,7 @@ curl "localhost:8080/api/v1/calls?from=...&to=..."
 
 Series names are stable — dashboards and the shipped alerts reference them; renames are breaking changes (a Go test, `pkg/metrics/collect_test.go`, pins them). Labels stay low-cardinality: `reason`, `kind`, `layer`, `result` — never pod, PK, or replica.
 
-`collect` serves `/metrics` on the internal port (`:8081`), scrapable through LOADING/RECOVERY; `query` on the external port (`:8080`); `maintain` on `PROFILER_METRICS_PORT` in deployment mode (CronJob pods exit too fast to scrape).
+`collect` serves `/metrics` on the internal port (`:8081`), scrapable through LOADING/RECOVERY; `query` on its dedicated metrics port (`PROFILER_METRICS_PORT`, default `:8081`), kept off the external port so the ingress cannot reach `/metrics` or `/debug/pprof` (reports2#15) and scraped pod-directly by a PodMonitor; `maintain` on `PROFILER_METRICS_PORT` in deployment mode (CronJob pods exit too fast to scrape).
 
 | Series | Type | Meaning |
 |---|---|---|

--- a/backend/charts/profiler-backend/templates/podmonitor-query.yaml
+++ b/backend/charts/profiler-backend/templates/podmonitor-query.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.metrics.serviceMonitor.enabled }}
+# query serves /metrics on a dedicated metrics port that no Service exposes, so
+# the ingress (which maps the external port at path /) never reaches it (04 §12).
+# A PodMonitor scrapes that port on the pod directly, mirroring the maintain loop.
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   name: {{ include "profiler-backend.fullname" . }}-query
   labels:
@@ -12,10 +15,8 @@ spec:
   selector:
     matchLabels:
       {{- include "profiler-backend.selectorLabels" (dict "root" . "component" "query") | nindent 6 }}
-  endpoints:
-    # query serves /metrics on the external port — it has no internal one
-    # (04 §12); the ingress publishes /api/v1 only.
-    - port: external
+  podMetricsEndpoints:
+    - port: metrics
       path: /metrics
       interval: {{ .Values.metrics.serviceMonitor.interval }}
 {{- end }}

--- a/backend/charts/profiler-backend/templates/query-deployment.yaml
+++ b/backend/charts/profiler-backend/templates/query-deployment.yaml
@@ -1,3 +1,9 @@
+{{- if eq (int .Values.query.port) (int .Values.query.metricsPort) }}
+{{- fail "query.port and query.metricsPort must differ: /metrics rides a separate listener the ingress does not publish (04 §12)" }}
+{{- end }}
+{{- if or (hasKey .Values.query.env "PROFILER_EXTERNAL_API_PORT") (hasKey .Values.query.env "PROFILER_METRICS_PORT") }}
+{{- fail "set query.port / query.metricsPort, not query.env.PROFILER_EXTERNAL_API_PORT or query.env.PROFILER_METRICS_PORT: query.env renders after the first-class ports and a duplicate key would override the declared containerPort" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,9 +39,17 @@ spec:
             - name: external
               containerPort: {{ .Values.query.port }}
               protocol: TCP
+            # Cluster-internal only: no Service exposes this port, and the
+            # ingress maps the external port alone (04 §12). Scraped pod-directly
+            # by the query PodMonitor.
+            - name: metrics
+              containerPort: {{ .Values.query.metricsPort }}
+              protocol: TCP
           env:
             - name: PROFILER_EXTERNAL_API_PORT
               value: {{ .Values.query.port | quote }}
+            - name: PROFILER_METRICS_PORT
+              value: {{ .Values.query.metricsPort | quote }}
             - name: COLLECTOR_HEADLESS_SVC
               value: {{ include "profiler-backend.collectorHeadless" . | quote }}
             - name: PROFILER_INTERNAL_API_PORT

--- a/backend/charts/profiler-backend/templates/query-service.yaml
+++ b/backend/charts/profiler-backend/templates/query-service.yaml
@@ -1,5 +1,7 @@
 # External API entry point (/api/v1). Exposure beyond the cluster (Ingress,
-# Route, LB) is operator-supplied per cluster convention (04 §4, §12).
+# Route, LB) is operator-supplied per cluster convention (04 §4, §12). Only the
+# external port is exposed here; /metrics and /debug/pprof listen on the pod's
+# metrics port, which no Service carries, so the ingress cannot reach them.
 apiVersion: v1
 kind: Service
 metadata:

--- a/backend/charts/profiler-backend/values.yaml
+++ b/backend/charts/profiler-backend/values.yaml
@@ -104,6 +104,10 @@ collector:
 query:
   replicas: 2
   port: 8080
+  # /metrics and /debug/pprof listen here, on a port no Service exposes and the
+  # ingress never maps (04 §12), so they stay cluster-internal. Must differ from
+  # query.port; scraped pod-directly by the query PodMonitor.
+  metricsPort: 8081
   # 03-lifecycle.md §7.3 shutdown budget.
   terminationGracePeriodSeconds: 45
   env: {}

--- a/backend/docs/design/02-read-contract.md
+++ b/backend/docs/design/02-read-contract.md
@@ -687,7 +687,8 @@ Stage 5 UI renders these as a "narrow your query" affordance (`profiler-plan.md`
 | `PROFILER_MAX_SCAN_BYTES` | `2GB` | Estimated-scan-byte ceiling for a `/calls` scan; over it, `400`. Counts compressed object bytes, per request; size it for the widest single query the deployment allows — the pod is sized from the §7.5 budget, not from this guard. |
 | `PROFILER_READ_MEMORY_BUDGET` | `512MB` | Process-wide read memory budget (§7.5): every reader charges materialized bytes against it. Size ≤ (pod limit − baseline) / overhead factor (≈2). |
 | `PROFILER_READ_BUDGET_WAIT` | `5s` | Bounded queue wait on a budget charge (§7.5); past it the request answers `503` + `Retry-After`. A negative value is rejected at startup. |
-| `PROFILER_EXTERNAL_API_PORT` | `8080` | Bind for `/api/v1/*`. |
+| `PROFILER_EXTERNAL_API_PORT` | `8080` | Bind for `/api/v1/*` and the UI. |
+| `PROFILER_METRICS_PORT` | `8081` | Bind for `/metrics` and `/debug/pprof`, on a listener the ingress does not publish (`04-storage-layout.md` §12). |
 | `S3_ENDPOINT` / `S3_BUCKET` / `S3_ACCESS_KEY` / `S3_SECRET_KEY` | — | Same as in `01-write-contract.md` §9. |
 
 ## 10. What this contract does NOT cover

--- a/backend/docs/design/03-lifecycle.md
+++ b/backend/docs/design/03-lifecycle.md
@@ -213,9 +213,9 @@ INIT → LOADING → READY → TERMINATING → exit
 ### 7.1 Startup
 
 1. Parse config; resolve `COLLECTOR_HEADLESS_SVC` once at boot to verify it resolves at all (warn but don't fail if it doesn't — collectors may come up later).
-2. Connect to S3 endpoint; verify bucket access. If unrecoverable → `FATAL`.
-3. Bind external API listener (`PROFILER_EXTERNAL_API_PORT`, default `8080`).
-4. Flip readiness to 200.
+2. Bind both listeners and set the gate to `LOADING`, before S3: the external API listener (`PROFILER_EXTERNAL_API_PORT`, default `8080`) and the metrics listener (`PROFILER_METRICS_PORT`, default `8081`). A probe must see `LOADING` rather than connection-refused while S3 comes up (PR 708 review #22). Bind synchronously so a port collision fails startup at once instead of hiding behind S3 retries. The metrics listener carries `/metrics` and `/debug/pprof` off the external port, so the ingress never exposes them (`04-storage-layout.md` §12).
+3. Connect to S3 endpoint; verify bucket access. If unrecoverable → `FATAL`.
+4. Flip readiness to 200 (`READY`).
 
 ### 7.2 Per-request
 
@@ -268,7 +268,8 @@ The `all` mode is documented as **dev-only**; production uses three separate k8s
 
 | Env | Default | Description |
 |---|---|---|
-| `PROFILER_EXTERNAL_API_PORT` | `8080` | HTTP listener for `/api/v1/*`. |
+| `PROFILER_EXTERNAL_API_PORT` | `8080` | HTTP listener for `/api/v1/*` and the UI. |
+| `PROFILER_METRICS_PORT` | `8081` | Separate listener for `/metrics` and `/debug/pprof`, kept off the external port so the ingress never exposes them (`04-storage-layout.md` §12). |
 | `COLLECTOR_HEADLESS_SVC` | — | Headless service DNS for collector discovery (`02-read-contract.md` §7.1). |
 | `PROFILER_SHUTDOWN_DRAIN_GRACE` | `30s` | Same semantics as `collect`. |
 

--- a/backend/docs/design/04-storage-layout.md
+++ b/backend/docs/design/04-storage-layout.md
@@ -210,9 +210,16 @@ spec:
             - name: external
               containerPort: 8080
               protocol: TCP
+            # Cluster-internal only: no Service carries it, so the ingress cannot
+            # reach /metrics or /debug/pprof (§12, reports2#15).
+            - name: metrics
+              containerPort: 8081
+              protocol: TCP
           env:
             - name: PROFILER_EXTERNAL_API_PORT
               value: "8080"
+            - name: PROFILER_METRICS_PORT
+              value: "8081"
             - name: COLLECTOR_HEADLESS_SVC
               value: "profiler-collector-headless"
             - name: PROFILER_OVERLAP_MARGIN
@@ -471,7 +478,7 @@ Run the full umbrella chart with `collector.replicas: 1`, `query.replicas: 1`, `
 ## 12. What this contract does NOT cover
 
 - **Ingress / external routing** to `/api/v1` — varies per cluster (Ingress controller, OpenShift Route, AWS ALB, etc.). The Helm chart exposes an `ingress.enabled / className / host` block; specific values are operator-supplied.
-- **Grafana dashboards.** The binary exposes `/metrics` (Prometheus format): `collect` on the internal port, `query` on the external port (it has no internal one), `maintain` on its metrics port in loop mode. The `profiler-backend` chart ships ServiceMonitor/PodMonitor objects and a PrometheusRule with the baseline alerts; dashboards land later.
+- **Grafana dashboards.** The binary exposes `/metrics` (Prometheus format): `collect` on the internal port, `query` and `maintain` on a dedicated metrics port (`PROFILER_METRICS_PORT`, default 8081). query serves `/metrics` and `/debug/pprof` on that port, not on the external one: the ingress maps the external port at path `/`, so keeping both off it is the only portable way to stop them leaking past the cluster boundary (reports2#15). The metrics port sits on no Service, so a PodMonitor scrapes it pod-directly. The `profiler-backend` chart ships ServiceMonitor/PodMonitor objects and a PrometheusRule with the baseline alerts; dashboards land later.
 - **Network policies** — supplied per-cluster.
 - **Service mesh** integration (Istio sidecar, Linkerd) — orthogonal to this contract; sidecars work as long as they don't terminate the agent's TCP stream.
 - **Backup of `metadata.sqlite`** — not needed: the database is rebuildable from PV contents (`03-lifecycle.md` §3.2).

--- a/backend/docs/design/07-ui-design.md
+++ b/backend/docs/design/07-ui-design.md
@@ -278,7 +278,8 @@ flowchart LR
 ```
 
 - **Serving.** `query` mounts an `embed.FS` at `/ui` on its existing router, with an SPA fallback to
-  `index.html` for client-side routes. `/api/v1/*`, `/metrics`, and `/api/v1/health/*` are unchanged. One
+  `index.html` for client-side routes. `/api/v1/*` and `/api/v1/health/*` are unchanged; `/metrics` now
+  lives on a separate metrics port, off the ingress-mapped external port (`04-storage-layout.md` §12). One
   origin means no CORS.
 - **API base.** When embedded, the UI calls `/api/v1` on its own origin. A build-time base-URL override
   keeps local development against a remote `query` working.

--- a/backend/docs/design/load-testing-plan.md
+++ b/backend/docs/design/load-testing-plan.md
@@ -262,7 +262,8 @@ fully observable — was verified live on OrbStack.
 Shipped:
 
 - **pprof** (§6.1): `net/http/pprof` in `collect`/`query`/`maintain` behind `PROFILER_PPROF_ENABLED` (default off),
-  on the internal/metrics port; on `query` it rides the external listener (its only port).
+  on the internal/metrics port; on `query` it rides the dedicated metrics port (`PROFILER_METRICS_PORT`), off the
+  external listener the ingress publishes (`04-storage-layout.md` §12, reports2#15).
 - **Stand** (§5.3): `backend/tools/load-generator/deploy/` — helmfile with `local` / `cluster` environments.
   qubership-monitoring-operator v0.88.0 comes straight from its git tag via helmfile `git::` charts (the helm-git
   plugin 1.3.0 is broken with helm 4); CRDs are a separate first release, `needs:` orders CRDs → operator → CRs.


### PR DESCRIPTION
## Why

The `query` service listened on a single port that served `/api/v1`, the UI, `/metrics`, and — with `PROFILER_PPROF_ENABLED` — `/debug/pprof`. The Ingress and HTTPRoute publish that port at path `/`, so `/metrics` and the pprof profiles were reachable from outside the cluster: a heap dump and a 30 s CPU-blocking `/debug/pprof/profile` among them.

## What

- New `PROFILER_METRICS_PORT` listener (default 8081) on `query`, mirroring the existing `maintain` subcommand. The external port now serves only `/api/v1`, the UI, and the health probes; `/metrics` and pprof move to the metrics port.
- The metrics port sits on no Service, so the ingress cannot map it. A `PodMonitor` scrapes it on the pod directly, replacing the query `ServiceMonitor`.
- Both listeners bind synchronously before S3, so a port collision fails startup at once instead of hiding behind S3 retries. A Helm guard rejects a `metricsPort` equal to `query.port`, or a port key set through `query.env`.
- Contracts and READMEs updated (`02`, `03`, `04` §4/§12, `07`, load-testing-plan): the earlier "query has no internal port / ingress publishes /api/v1 only" claims are corrected.

Compatible with `qubership-monitoring-operator` out of the box: both its Prometheus (`podMonitorSelector: {}`) and VictoriaMetrics (`VMAgent selectAllByDefault: true`, pinned `operator:v0.33.0` converter) stacks scrape PodMonitors by default.

## How to verify

- [ ] `cd backend && go test ./apps/profiler-backend/... ./libs/query/...` — 148 tests pass, including `TestQueryHandlersSplit` and `TestMetricsMux`.
- [ ] `helm template backend/charts/profiler-backend --set s3.auth.accessKey=ak --set s3.auth.secretKey=sk --set minio.enabled=true --set metrics.serviceMonitor.enabled=true --set query.ingress.enabled=true --set query.ingress.host=q.example` — query Deployment exposes `external` + `metrics` ports and `PROFILER_METRICS_PORT`; query Service exposes only `external`; `podmonitor-query` renders and `servicemonitor-query` does not; Ingress/HTTPRoute map only the external port.
- [ ] Guards fail as expected: `--set query.metricsPort=8080` and `--set query.env.PROFILER_METRICS_PORT=9999`.
- [ ] Run `profiler-backend query` with `PROFILER_METRICS_PORT=8081 PROFILER_PPROF_ENABLED=true`: `:8081/metrics` and `:8081/debug/pprof/` serve; `:8080/metrics` and `:8080/debug/pprof/` do not.

Closes https://github.com/Netcracker/qubership-profiler-agent/issues/851

🤖 Generated with [Claude Code](https://claude.com/claude-code)
