### PR TITLE
fix(profiler): serve the SPA under /ui in the built image

### DIFF
--- a/backend/apps/profiler-backend/Dockerfile
+++ b/backend/apps/profiler-backend/Dockerfile
@@ -14,6 +14,11 @@ COPY apps/ui/package.json apps/ui/package-lock.json ./
 RUN npm ci --no-audit --no-fund
 
 COPY apps/ui/ ./
+# The product serves the SPA under /ui (07-ui-design.md §6); the query binary
+# reads this base back out of the built index.html. Pass
+# --build-arg UI_BASE_PATH=/ for a root build.
+ARG UI_BASE_PATH=/ui/
+ENV UI_BASE_PATH=$UI_BASE_PATH
 RUN npm run build
 
 FROM golang:1.26.2-alpine3.22@sha256:7ef941168f213aa115df2e61364d67682129e99dc8188b734139dea862cc7d31 AS builder

--- a/backend/apps/ui/README.md
+++ b/backend/apps/ui/README.md
@@ -25,10 +25,16 @@ npm run build      # tsc + vite build into dist/
 ## Deployment
 
 `embed.go` embeds `dist/` into the query binary (`go:embed`), which serves it at `/ui` with an SPA
-fallback (07 §6). Run `npm run build` before `go build ./apps/profiler-backend` for a UI-carrying
-binary; a build without it still compiles and serves `/api/v1`, logging that `/ui` is disabled. The
-profiler-backend Dockerfile builds the bundle in a node stage, so `docker compose up --build` needs no
-host toolchain. End to end: `make query-ui` in `it-e2e/`.
+fallback (07 §6). Run `UI_BASE_PATH=/ui/ npm run build` before `go build ./apps/profiler-backend` for a
+UI-carrying binary; a build without it still compiles and serves `/api/v1`, logging that `/ui` is
+disabled. The profiler-backend Dockerfile builds the bundle in a node stage, so `docker compose up --build`
+needs no host toolchain. End to end: `make query-ui` in `it-e2e/`.
+
+`UI_BASE_PATH` is the one place the sub-path is configured: Vite bakes it into `index.html`, the router
+takes its basename from it, and the binary reads it back out to pick the serving prefix. The image
+defaults to `/ui/`; `docker build --build-arg UI_BASE_PATH=/` produces a root build for a deployment
+that owns the whole origin. Under the default the app answers only below `/ui`, and the origin root
+redirects there.
 
 ## Layout
 

--- a/backend/apps/ui/package.json
+++ b/backend/apps/ui/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "dev:mock": "VITE_ENABLE_MSW=1 vite",
+    "dev": "UI_BASE_PATH=/ui/ vite",
+    "dev:mock": "VITE_ENABLE_MSW=1 UI_BASE_PATH=/ui/ vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -b",

--- a/backend/docs/design/07-ui-design.md
+++ b/backend/docs/design/07-ui-design.md
@@ -280,6 +280,11 @@ flowchart LR
 - **Serving.** `query` mounts an `embed.FS` at `/ui` on its existing router, with an SPA fallback to
   `index.html` for client-side routes. `/api/v1/*`, `/metrics`, and `/api/v1/health/*` are unchanged. One
   origin means no CORS.
+- **Base path.** The sub-path is a build-time switch: `UI_BASE_PATH` sets the Vite base, the router
+  basename follows it, and the binary reads the base back out of the built `index.html`. The image
+  builds with `/ui/`; `--build-arg UI_BASE_PATH=/` produces a root build for a deployment that owns the
+  whole origin. Under a sub-path build the app answers only below its base, and `/` redirects there —
+  `/calls` at the origin root is not a second entry point.
 - **API base.** When embedded, the UI calls `/api/v1` on its own origin. A build-time base-URL override
   keeps local development against a remote `query` working.
 - **Local development.** Vite dev server proxies `/api/v1` to a running `query` (`:8080`), or to an MSW

--- a/backend/libs/query/api.go
+++ b/backend/libs/query/api.go
@@ -69,6 +69,13 @@ func (s *Service) routes(e *echo.Echo) {
 			e.GET("/", s.handleUI, middleware.Gzip())
 			e.GET("/*", s.handleUI, middleware.Gzip())
 		} else {
+			// A sub-path build leaves the origin root unserved, so send it to
+			// the app: opening the service host lands on the UI instead of a
+			// 404. The redirect is temporary because the base is a build-time
+			// switch — a root rebuild must not fight a cached 301.
+			e.GET("/", func(c echo.Context) error {
+				return c.Redirect(http.StatusFound, s.uiPrefix+"/")
+			})
 			e.GET(s.uiPrefix, s.handleUI, middleware.Gzip())
 			e.GET(s.uiPrefix+"/*", s.handleUI, middleware.Gzip())
 		}

--- a/backend/libs/query/ui_test.go
+++ b/backend/libs/query/ui_test.go
@@ -58,6 +58,32 @@ func TestUIServing(t *testing.T) {
 				}
 			})
 
+			t.Run("the origin root reaches the app", func(t *testing.T) {
+				client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+					return http.ErrUseLastResponse
+				}}
+				resp, err := client.Get(server.URL + "/")
+				require.NoError(t, err)
+				require.NoError(t, resp.Body.Close())
+				if tc.base == "" {
+					assert.Equal(t, http.StatusOK, resp.StatusCode)
+					return
+				}
+				// A sub-path build owns nothing at the root but the redirect.
+				assert.Equal(t, http.StatusFound, resp.StatusCode)
+				assert.Equal(t, tc.base+"/", resp.Header.Get("Location"))
+			})
+
+			t.Run("a sub-path build serves the app only under its base", func(t *testing.T) {
+				if tc.base == "" {
+					t.Skip("a root build owns every path by design")
+				}
+				// The documented routes live under the base; the same route at
+				// the root is not a second entry point into the app.
+				resp, _ := get("/calls")
+				assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+			})
+
 			t.Run("client-side routes fall back to index.html", func(t *testing.T) {
 				for _, p := range []string{tc.base + "/calls", tc.base + "/pods", tc.base + "/tree/ns:svc:pod:1:2:3:4", tc.base + "/no/such/route"} {
 					resp, body := get(p)

--- a/it-e2e/e2e-query/query-ui.spec.ts
+++ b/it-e2e/e2e-query/query-ui.spec.ts
@@ -8,9 +8,10 @@ import { expect, test } from '@playwright/test';
 test('discovery, calls filtering, and a drill into the call tree', async ({ page, context }) => {
   await page.goto('/ui/calls');
 
-  // Pick a quick range; the rail discovers services for the draft window
-  // before Apply.
-  await page.getByText('15 min', { exact: true }).click();
+  // Pick a quick range from the time-range popover; the rail discovers
+  // services for the draft window before Apply.
+  await page.getByRole('button', { name: 'Time range', exact: true }).click();
+  await page.getByText('Last 15 minutes', { exact: true }).click();
   await expect(page.getByText('shop ·')).toBeVisible({ timeout: 30_000 });
   await expect(page.getByText('e2e', { exact: true })).toBeVisible();
 
@@ -20,7 +21,7 @@ test('discovery, calls filtering, and a drill into the call tree', async ({ page
     .locator('.ant-tree-checkbox')
     .first()
     .click();
-  await page.getByRole('button', { name: 'Apply' }).click();
+  await page.getByRole('button', { name: 'Apply', exact: true }).click();
 
   // The default >500ms chip hides the sub-500ms half of the seeded mix
   // (the assertions stay count-free: reseeding an already-running stack
@@ -49,10 +50,37 @@ test('discovery, calls filtering, and a drill into the call tree', async ({ page
   await expect(treePage.getByText(/Api\.handle/).first()).toBeVisible();
   await expect(treePage.getByText('request.id').first()).toBeVisible();
 
+  // The same URL served cold: /ui/tree/:pk is a deep-link an operator can
+  // paste, not only an in-app navigation target.
+  await treePage.reload();
+  await expect(treePage.getByText(/Api\.handle/).first()).toBeVisible({ timeout: 30_000 });
+
   // Hotspots groups by self time; the DB leaf dominates the seeded shape.
   // (Scoped to the active pane: AntD keeps inactive tab content in the DOM.)
   await treePage.getByRole('tab', { name: 'Hotspots' }).click();
   await expect(
     treePage.getByRole('tabpanel', { name: 'Hotspots' }).getByText(/OrderDao\.query/).first(),
   ).toBeVisible();
+});
+
+// The image builds the bundle under /ui (07 §6), so the documented routes have
+// to render against the deployed base, not just the Vite default. This is the
+// smoke test for that base: a route the first test never opens, plus the origin
+// root, which carries no app of its own.
+test('the documented /ui routes render against the deployed base', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/ui\/calls(\?|$)/);
+
+  await page.goto('/ui/pods');
+  await expect(page.getByText('Pods Info')).toBeVisible();
+
+  // Pods Info carries the same period picker and rail as Calls (09 §4).
+  // Committing a range is enough here: with nothing selected in the rail the
+  // screen lists every pod-restart in the window, so Apply stays grey.
+  await page.getByRole('button', { name: 'Time range', exact: true }).click();
+  await page.getByText('Last 15 minutes', { exact: true }).click();
+  await expect(page.getByText('shop ·')).toBeVisible({ timeout: 30_000 });
+
+  // The seeded pods land as namespace/service/pod rows.
+  await expect(page.getByText(/e2e\/shop\/shop-/).first()).toBeVisible({ timeout: 30_000 });
 });


### PR DESCRIPTION
## Why

The production image built the UI bundle with Vite's default `/` base, while the design doc, the README, and the router all place the app at `/ui`. `/ui/calls` loaded JavaScript and rendered a blank page; the app worked only at the undocumented `/calls`. Under a sub-path build the origin root served nothing at all.

Fixes #848.

## What

- The Dockerfile builds the bundle with `UI_BASE_PATH=/ui/`, exposed as a build arg — `docker build --build-arg UI_BASE_PATH=/` still produces a root build for a deployment that owns the whole origin.
- The dev scripts use the same base, so local development, the image, and the e2e stack agree on the URLs.
- Under a sub-path build `GET /` redirects to the app (302, not 301: the base is a build-time switch, and a later root rebuild must not fight a cached permanent redirect). `/calls` at the origin root stays a 404 — one entry point, not two.
- `07-ui-design.md` §6 and the UI README record the switch and what answers under each mode.
- The e2e suite deep-links `/ui/pods`, reloads `/ui/tree/:pk`, and checks the root redirect. It previously drove a single route, so a base-path regression could only be caught by the routes it never opened.
- Drive-by in the same suite: the time-range selectors had drifted from the period popover (a `15 min` label that no longer exists), which made the suite fail before it reached any of the above.

## How to verify

- `cd backend && go test ./libs/query/` — covers the root redirect, the sub-path 404, and the SPA fallback for both bases.
- `cd it-e2e && make query-ui` — builds the image, seeds the stack through the real agent protocol, and runs both Playwright tests. Green locally: 2 passed.
- By hand against a running stack: `curl -sI http://localhost:8080/` returns `302` with `Location: /ui/`, and `/ui/calls`, `/ui/pods`, `/ui/tree/:pk` render on a cold load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUMLtoyWk1y4gxttgvzrqJ