### PR TITLE
chore(renovate): use shared presets

### DIFF
--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
   pull_request:
     paths:
       - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
 
 permissions: read-all
 

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -21,4 +21,4 @@ jobs:
           persist-credentials: false
 
       - name: Validate renovate.json
-        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator renovate.json
+        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator --strict --no-global renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "github>Netcracker/renovate-config:annotated-versions",
     "github>Netcracker/renovate-config:github-actions",
     "github>Netcracker/renovate-config:go",
+    "github>Netcracker/renovate-config:maven-groupid",
     "github>Netcracker/renovate-config:netcracker-dependencies"
   ],
   "labels": [
@@ -47,12 +48,6 @@
       "allowedVersions": "< 7",
       "matchPackageNames": [
         "javax:javaee-api"
-      ]
-    },
-    {
-      "groupName": "checkerframework",
-      "matchPackageNames": [
-        "org.checkerframework{/,}**"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
+    "github>Netcracker/renovate-config:base",
+    "github>Netcracker/renovate-config:annotated-versions",
+    "github>Netcracker/renovate-config:github-actions",
+    "github>Netcracker/renovate-config:go",
+    "github>Netcracker/renovate-config:netcracker-dependencies"
   ],
   "labels": [
     "dependencies"
@@ -128,11 +132,17 @@
       ]
     },
     {
-      "description": "Group all GitHub Actions updates into a single PR",
-      "groupName": "GitHub Actions",
-      "matchManagers": [
-        "github-actions"
-      ]
+      "description": "Disable Docker images that are unavailable from their registries",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "centos7/openjdk11-x64",
+        "centos7/openjdk11-x86",
+        "alpine/openjdk17",
+        "alpine/openjdk21"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -56,12 +56,6 @@
       ]
     },
     {
-      "groupName": "jmh",
-      "matchPackageNames": [
-        "org.openjdk.jmh{/,}**"
-      ]
-    },
-    {
       "groupName": "com.github.vlsi",
       "matchPackageNames": [
         "com.github.vlsi{/,}**"
@@ -113,16 +107,14 @@
       ]
     },
     {
-      "description": "Pin sample-apps/it-spring-boot-3 to Spring Boot 3.x; create it-spring-boot-4 module when bumping major",
+      "description": "Keep Spring Boot 3 example modules on Spring Boot 3",
       "groupName": "Spring Boot 3 sample app",
       "matchFileNames": [
-        "sample-apps/it-spring-boot-3/**"
+        "backend/examples/spring-boot-3-*/**"
       ],
       "allowedVersions": "< 4",
       "matchPackageNames": [
-        "org.springframework.boot{/,}**",
-        "org.springframework{/,}**",
-        "org.springframework.session{/,}**"
+        "org.springframework.boot{/,}**"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -13,28 +13,11 @@
   ],
   "automerge": true,
   "platformAutomerge": false,
-  "schedule": [
-    "every 4 day"
-  ],
   "ignorePaths": [
     "**/node_modules/**",
     "plugins/*/build.gradle.kts"
   ],
   "packageRules": [
-    {
-      "description": "Run Go toolchain updates weekly on Monday",
-      "schedule": [
-        "every 1 weeks on Monday"
-      ],
-      "matchDatasources": [
-        "docker",
-        "golang-version"
-      ],
-      "matchPackageNames": [
-        "go",
-        "golang"
-      ]
-    },
     {
       "groupName": "errorprone",
       "matchPackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -21,23 +21,17 @@
   ],
   "packageRules": [
     {
-      "description": "Update Go version everywhere at once: build image, go.mod and GitHub Actions workflows",
-      "groupName": "Go",
+      "description": "Run Go toolchain updates weekly on Monday",
       "schedule": [
         "every 1 weeks on Monday"
       ],
       "matchDatasources": [
         "docker",
-        "github-actions",
-        "github-releases",
-        "golang-version",
-        "gomod"
+        "golang-version"
       ],
       "matchPackageNames": [
         "go",
-        "golang",
-        "actions/go-versions",
-        "actions/setup-go"
+        "golang"
       ]
     },
     {


### PR DESCRIPTION
## Why

Renovate rules should follow organization presets while preserving this repository's dependency constraints.

## What

- Use the shared base, annotated versions, GitHub Actions, Go, Maven groupId, and Netcracker dependency presets.
- Inherit the shared weekly update schedule instead of the repository-wide four-day schedule and the separate Go schedule.
- Group Maven updates by `groupId` while preserving repository-specific version constraints and cross-group rules.
- Keep repository-specific dependency constraints, including the Spring Boot sample limit.
- Remove ineffective or redundant rules and disable unavailable image lookups reported by the Dependency Dashboard.
- Validate both `renovate.json` and its workflow in CI.

Related shared configuration: [Netcracker/renovate-config#29](https://github.com/Netcracker/renovate-config/pull/29), [Netcracker/renovate-config#31](https://github.com/Netcracker/renovate-config/pull/31), and [Netcracker/renovate-config#34](https://github.com/Netcracker/renovate-config/pull/34).
