### PR TITLE
fix(agent): keep the JVM alive when the profiler cannot start

### DIFF
--- a/boot/src/main/java/com/netcracker/profiler/agent/Bootstrap.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/Bootstrap.java
@@ -65,9 +65,9 @@ public class Bootstrap {
 
             return;
         }
-        addJBossModulesSystemPkg();
         Bootstrap.inst = inst;
         try {
+            addJBossModulesSystemPkg();
             startProfiler(agentArgs);
         } catch (Throwable e) {
             // libinstrument aborts the JVM on any exception leaving premain, killing the
@@ -185,23 +185,26 @@ public class Bootstrap {
     /**
      * Reads the plugin identities and {@code Implementation-Version} from a JAR file.
      *
-     * @return {@code null} when the file carries no plugin, or cannot be read
+     * <p>A readable manifest that declares no entry points yields an entry with no identities: the
+     * file is not a plugin, but it is intact and safe to hand on. {@code null} is reserved for a
+     * file the loader cannot read at all, which must not be handed on -- opening it again downstream
+     * would only throw.
+     *
+     * @return {@code null} when the file has no manifest, or cannot be read
      */
     private static PluginJarInfo readPluginJarInfo(String jarPath) {
         try (JarInputStream jis = new JarInputStream(Files.newInputStream(Paths.get(jarPath)))) {
             Manifest man = jis.getManifest();
             if (man == null) {
+                logger.warning("Profiler: " + jarPath + " has no manifest, the file is skipped");
                 return null;
             }
             Attributes attrs = man.getMainAttributes();
-            Set<String> pluginIds = extractPluginIds(attrs);
-            if (pluginIds.isEmpty()) {
-                return null;
-            }
             String version = attrs.getValue("Implementation-Version");
-            return new PluginJarInfo(jarPath, pluginIds, version);
+            return new PluginJarInfo(jarPath, extractPluginIds(attrs), version);
         } catch (IOException e) {
-            logger.log(Level.WARNING, "Profiler: unable to read manifest from " + jarPath, e);
+            logger.log(Level.WARNING, "Profiler: unable to read the manifest of " + jarPath
+                    + ", the file is skipped", e);
             return null;
         }
     }
@@ -257,17 +260,26 @@ public class Bootstrap {
      * <p>Loading a plugin twice gives each copy its own {@link PluginClassLoader}, and classes from
      * one copy then fail to cast to the same-named classes of the other. The newest copy wins, and
      * the JARs it displaces are named in a warning so the stale files can be removed. Files that
-     * carry no plugin at all pass through untouched.
+     * carry no plugin pass through untouched; files the loader cannot read are dropped here rather
+     * than downstream, where opening them again would fail the whole agent.
      */
     private static List<String> deduplicatePlugins(List<String> plugins) {
         Map<String, List<PluginJarInfo>> byPluginId = new LinkedHashMap<String, List<PluginJarInfo>>();
         List<String> result = new ArrayList<String>();
 
         for (String jarPath : plugins) {
+            if (!jarPath.endsWith(".jar")) {
+                // A .class explicitly passed on the command line, which loadPlugins runs directly.
+                result.add(jarPath);
+                continue;
+            }
             PluginJarInfo info = readPluginJarInfo(jarPath);
             if (info == null) {
-                // Carries no plugin: a .class explicitly passed on the command line, agent.jar,
-                // boot.jar, or a JAR whose manifest could not be read.
+                // Unreadable, and readPluginJarInfo has already said so.
+                continue;
+            }
+            if (info.pluginIds.isEmpty()) {
+                // Intact but not a plugin: agent.jar and boot.jar take this path.
                 result.add(jarPath);
                 continue;
             }
@@ -287,29 +299,42 @@ public class Bootstrap {
         Set<List<String>> reported = new HashSet<>();
         String lib = new File(DumpRootResolverAgent.PROFILER_HOME).getAbsolutePath();
         for (Map.Entry<String, List<PluginJarInfo>> entry : byPluginId.entrySet()) {
-            List<PluginJarInfo> jars = entry.getValue();
-            if (jars.size() == 1) {
+            if (entry.getValue().size() == 1) {
                 continue;
             }
+            // The candidates arrive in File.listFiles() order, which is unspecified. Sorting first
+            // keeps the pick reproducible when the versions cannot separate the copies.
+            List<PluginJarInfo> jars = new ArrayList<PluginJarInfo>(entry.getValue());
+            Collections.sort(jars, new Comparator<PluginJarInfo>() {
+                public int compare(PluginJarInfo left, PluginJarInfo right) {
+                    return left.jarPath.compareTo(right.jarPath);
+                }
+            });
+
             PluginJarInfo winner = jars.get(0);
+            boolean versionsDiffer = false;
             List<String> jarPaths = new ArrayList<String>();
             for (PluginJarInfo jar : jars) {
                 jarPaths.add(jar.jarPath);
-                if (compareVersions(jar.version, winner.version) > 0) {
+                int cmp = compareVersions(jar.version, winner.version);
+                if (cmp != 0) {
+                    versionsDiffer = true;
+                }
+                if (cmp > 0) {
                     winner = jar;
                 }
             }
-            Collections.sort(jarPaths);
             boolean firstReport = reported.add(jarPaths);
 
             StringBuilder sb = new StringBuilder();
             sb.append("Profiler: plugin '").append(entry.getKey()).append("' is provided by several JARs. ")
-                    .append("Only the newest one is loaded; remove the stale file(s) listed below:\n");
+                    .append(versionsDiffer
+                            ? "Only the newest one is loaded"
+                            : "Their versions do not tell them apart, so the first one by name is loaded")
+                    .append("; remove the duplicate file(s) listed below:\n");
             for (PluginJarInfo jar : jars) {
                 sb.append("  - ").append(jar.jarPath.replace(lib, "$esc"));
-                if (jar.version != null) {
-                    sb.append(" (version=").append(jar.version).append(")");
-                }
+                sb.append(" (version=").append(jar.version == null ? "unknown" : jar.version).append(")");
                 if (jar == winner) {
                     sb.append(" -- loaded\n");
                 } else {
@@ -325,7 +350,16 @@ public class Bootstrap {
         }
 
         for (Map.Entry<String, List<PluginJarInfo>> entry : byPluginId.entrySet()) {
-            for (PluginJarInfo jar : entry.getValue()) {
+            List<PluginJarInfo> jars = entry.getValue();
+            // A displaced JAR is dropped whole, so a plugin only it provided goes with it. Loading
+            // it for that one plugin would reintroduce the duplicate the drop just resolved, so the
+            // loss is named rather than hidden.
+            if (jars.size() == 1 && displaced.contains(jars.get(0).jarPath)) {
+                logger.warning("Profiler: plugin '" + entry.getKey() + "' is provided only by "
+                        + jars.get(0).jarPath.replace(lib, "$esc")
+                        + ", which was skipped as a duplicate. The plugin is not loaded.");
+            }
+            for (PluginJarInfo jar : jars) {
                 if (!displaced.contains(jar.jarPath) && !result.contains(jar.jarPath)) {
                     result.add(jar.jarPath);
                 }

--- a/boot/src/main/java/com/netcracker/profiler/agent/Bootstrap.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/Bootstrap.java
@@ -6,8 +6,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.*;
@@ -193,8 +191,12 @@ public class Bootstrap {
      * @return {@code null} when the file has no manifest, or cannot be read
      */
     private static PluginJarInfo readPluginJarInfo(String jarPath) {
-        try (JarInputStream jis = new JarInputStream(Files.newInputStream(Paths.get(jarPath)))) {
-            Manifest man = jis.getManifest();
+        // JarFile is the reader PluginClassLoader opens the file with. Classifying through a
+        // different one would let the two disagree: JarInputStream reads a manifest out of a file
+        // truncated before its central directory, which JarFile cannot open at all, and a file that
+        // passes here only to fail there costs every plugin rather than itself.
+        try (JarFile jar = new JarFile(jarPath)) {
+            Manifest man = jar.getManifest();
             if (man == null) {
                 logger.warning("Profiler: " + jarPath + " has no manifest, the file is skipped");
                 return null;
@@ -231,9 +233,18 @@ public class Bootstrap {
             if (r == null) {
                 return isNumeric(l) ? 1 : -1;
             }
-            int cmp = isNumeric(l) && isNumeric(r)
-                    ? new BigInteger(l).compareTo(new BigInteger(r))
-                    : l.compareToIgnoreCase(r);
+            boolean leftNumeric = isNumeric(l);
+            boolean rightNumeric = isNumeric(r);
+            int cmp;
+            if (leftNumeric && rightNumeric) {
+                cmp = new BigInteger(l).compareTo(new BigInteger(r));
+            } else if (leftNumeric != rightNumeric) {
+                // 4.0.5.1 is newer than 4.0.5-rc1: a numeric segment outranks a qualifier, the same
+                // way a missing segment does. Comparing them as text would rank rc1 above the .1.
+                cmp = leftNumeric ? 1 : -1;
+            } else {
+                cmp = l.compareToIgnoreCase(r);
+            }
             if (cmp != 0) {
                 return cmp;
             }
@@ -291,7 +302,7 @@ public class Bootstrap {
 
         // A JAR is loaded when it is the newest provider of every identity it declares, which keeps
         // the decision consistent for a JAR that ships several plugins at once.
-        Set<String> displaced = new HashSet<>();
+        Map<String, String> displacedBy = new LinkedHashMap<String, String>();
         // One pair of duplicated JARs normally collides on several identities at once, for example
         // on an explicit Plugin-Id and on the entry-point set. Repeating the same advice per
         // identity would only bury it, so each set of JARs is reported once, under the first
@@ -338,7 +349,7 @@ public class Bootstrap {
                 if (jar == winner) {
                     sb.append(" -- loaded\n");
                 } else {
-                    displaced.add(jar.jarPath);
+                    displacedBy.put(jar.jarPath, winner.jarPath);
                     sb.append(" -- skipped\n");
                 }
             }
@@ -351,16 +362,19 @@ public class Bootstrap {
 
         for (Map.Entry<String, List<PluginJarInfo>> entry : byPluginId.entrySet()) {
             List<PluginJarInfo> jars = entry.getValue();
-            // A displaced JAR is dropped whole, so a plugin only it provided goes with it. Loading
-            // it for that one plugin would reintroduce the duplicate the drop just resolved, so the
-            // loss is named rather than hidden.
-            if (jars.size() == 1 && displaced.contains(jars.get(0).jarPath)) {
-                logger.warning("Profiler: plugin '" + entry.getKey() + "' is provided only by "
-                        + jars.get(0).jarPath.replace(lib, "$esc")
-                        + ", which was skipped as a duplicate. The plugin is not loaded.");
+            // A displaced JAR is dropped whole, so an identity only it provided is left without a
+            // provider. Loading it for that one identity would reintroduce the duplicate the drop
+            // just resolved, so the gap is named rather than hidden. The JAR that displaced it is
+            // named too: it may well provide the same plugin under one of its other identities,
+            // and saying only "not loaded" would send the operator after the wrong file.
+            if (jars.size() == 1 && displacedBy.containsKey(jars.get(0).jarPath)) {
+                String skipped = jars.get(0).jarPath;
+                logger.warning("Profiler: nothing loaded provides plugin '" + entry.getKey()
+                        + "'. Its only provider " + skipped.replace(lib, "$esc")
+                        + " was skipped in favor of " + displacedBy.get(skipped).replace(lib, "$esc") + ".");
             }
             for (PluginJarInfo jar : jars) {
-                if (!displaced.contains(jar.jarPath) && !result.contains(jar.jarPath)) {
+                if (!displacedBy.containsKey(jar.jarPath) && !result.contains(jar.jarPath)) {
                     result.add(jar.jarPath);
                 }
             }

--- a/boot/src/main/java/com/netcracker/profiler/agent/Bootstrap.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/Bootstrap.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigInteger;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -24,12 +25,12 @@ public class Bootstrap {
 
     static class PluginJarInfo {
         final String jarPath;
-        final List<String> pluginId;
+        final Set<String> pluginIds;
         final String version;
 
-        PluginJarInfo(String jarPath, List<String> pluginId, String version) {
+        PluginJarInfo(String jarPath, Set<String> pluginIds, String version) {
             this.jarPath = jarPath;
-            this.pluginId = pluginId;
+            this.pluginIds = pluginIds;
             this.version = version;
         }
     }
@@ -66,6 +67,17 @@ public class Bootstrap {
         }
         addJBossModulesSystemPkg();
         Bootstrap.inst = inst;
+        try {
+            startProfiler(agentArgs);
+        } catch (Throwable e) {
+            // libinstrument aborts the JVM on any exception leaving premain, killing the
+            // application before it runs a line of its own. Startup failures stop here instead,
+            // and the application keeps running unprofiled.
+            logger.severe("Profiler: initialization failed, the application continues without profiling", e);
+        }
+    }
+
+    private static void startProfiler(String agentArgs) {
         List<String> plugins = split(agentArgs);
         if (plugins.isEmpty()) {
             File lib = new File(DumpRootResolverAgent.PROFILER_HOME, "lib");
@@ -129,37 +141,51 @@ public class Bootstrap {
     }
 
     /**
-     * Extract Plugin-Id from JAR manifest attributes.
-     * Falls back to extracting from Entry-Points if Plugin-Id is not present.
+     * Collects every identity a JAR manifest claims for its plugin, so that two JARs shipping the
+     * same plugin can be recognized as duplicates.
+     *
+     * <p>A JAR is identified by its {@code Plugin-Id}, by the enhancer names in its
+     * {@code Entry-Points} ({@code ...EnhancerPlugin_activemq} yields {@code activemq}), and by the
+     * entry-point set as a whole. The entry-point set is what matches a JAR built before
+     * {@code Plugin-Id} existed with the release that introduced the attribute.
+     *
+     * @return every identity the manifest declares, empty when it declares no entry points
      */
-    static List<String> extractPluginId(Attributes attrs) {
+    static Set<String> extractPluginIds(Attributes attrs) {
         if (attrs == null) {
-            return Collections.emptyList();
+            return Collections.emptySet();
         }
+        String entryPoints = attrs.getValue("Entry-Points");
+        if (entryPoints == null || entryPoints.trim().isEmpty()) {
+            // Not a plugin JAR: agent.jar and boot.jar take this path.
+            return Collections.emptySet();
+        }
+        Set<String> result = new LinkedHashSet<>();
         String pluginId = attrs.getValue("Plugin-Id");
         if (pluginId != null) {
-            return Collections.singletonList(pluginId);
+            result.add(pluginId);
         }
-        // Fallback: extract from Entry-Points (EnhancerPlugin_XXX -> XXX)
         // Example: com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_activemq
-        String entryPoints = attrs.getValue("Entry-Points");
-        List<String> result = new ArrayList<>();
-        if (entryPoints != null) {
-            for (String entry : entryPoints.split("\\s+")) {
-                int idx = entry.lastIndexOf("EnhancerPlugin_");
-                if (idx >= 0) {
-                    String suffix = entry.substring(idx + "EnhancerPlugin_".length());
-                    if (!suffix.isEmpty()) {
-                        result.add(suffix);
-                    }
+        String[] entries = entryPoints.trim().split("\\s+");
+        for (String entry : entries) {
+            int idx = entry.lastIndexOf("EnhancerPlugin_");
+            if (idx >= 0) {
+                String suffix = entry.substring(idx + "EnhancerPlugin_".length());
+                if (!suffix.isEmpty()) {
+                    result.add(suffix);
                 }
             }
         }
+        String[] sortedEntries = entries.clone();
+        Arrays.sort(sortedEntries);
+        result.add("entry-points:" + String.join(" ", sortedEntries));
         return result;
     }
 
     /**
-     * Read Plugin-Id and Implementation-Version from a JAR file.
+     * Reads the plugin identities and {@code Implementation-Version} from a JAR file.
+     *
+     * @return {@code null} when the file carries no plugin, or cannot be read
      */
     private static PluginJarInfo readPluginJarInfo(String jarPath) {
         try (JarInputStream jis = new JarInputStream(Files.newInputStream(Paths.get(jarPath)))) {
@@ -168,12 +194,12 @@ public class Bootstrap {
                 return null;
             }
             Attributes attrs = man.getMainAttributes();
-            List<String> pluginId = extractPluginId(attrs);
-            if (pluginId.isEmpty()) {
+            Set<String> pluginIds = extractPluginIds(attrs);
+            if (pluginIds.isEmpty()) {
                 return null;
             }
             String version = attrs.getValue("Implementation-Version");
-            return new PluginJarInfo(jarPath, pluginId, version);
+            return new PluginJarInfo(jarPath, pluginIds, version);
         } catch (IOException e) {
             logger.log(Level.WARNING, "Profiler: unable to read manifest from " + jarPath, e);
             return null;
@@ -181,57 +207,128 @@ public class Bootstrap {
     }
 
     /**
-     * Check for duplicate Plugin-Ids and exclude all duplicates from loading.
-     * JARs with unique Plugin-Id are loaded normally.
-     * JARs with duplicate Plugin-Id are skipped and a warning is logged.
+     * Compares {@code Implementation-Version} values so the newest copy of a duplicated plugin can
+     * be picked. Numeric segments compare numerically, a qualifier loses to the plain release it
+     * qualifies ({@code 4.0.5-SNAPSHOT} &lt; {@code 4.0.5}), and a missing version loses to any
+     * version.
+     */
+    static int compareVersions(String left, String right) {
+        if (left == null || right == null) {
+            return left == null ? (right == null ? 0 : -1) : 1;
+        }
+        String[] leftParts = left.split("[.\\-+_]");
+        String[] rightParts = right.split("[.\\-+_]");
+        for (int i = 0; i < Math.max(leftParts.length, rightParts.length); i++) {
+            String l = i < leftParts.length ? leftParts[i] : null;
+            String r = i < rightParts.length ? rightParts[i] : null;
+            if (l == null) {
+                // 4.0 < 4.0.1, but 4.0.5 > 4.0.5-SNAPSHOT
+                return isNumeric(r) ? -1 : 1;
+            }
+            if (r == null) {
+                return isNumeric(l) ? 1 : -1;
+            }
+            int cmp = isNumeric(l) && isNumeric(r)
+                    ? new BigInteger(l).compareTo(new BigInteger(r))
+                    : l.compareToIgnoreCase(r);
+            if (cmp != 0) {
+                return cmp;
+            }
+        }
+        return 0;
+    }
+
+    private static boolean isNumeric(String s) {
+        if (s.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < s.length(); i++) {
+            if (s.charAt(i) < '0' || s.charAt(i) > '9') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Keeps a single JAR per plugin, so that a stale copy left next to the current one cannot make
+     * the profiler load one plugin twice.
+     *
+     * <p>Loading a plugin twice gives each copy its own {@link PluginClassLoader}, and classes from
+     * one copy then fail to cast to the same-named classes of the other. The newest copy wins, and
+     * the JARs it displaces are named in a warning so the stale files can be removed. Files that
+     * carry no plugin at all pass through untouched.
      */
     private static List<String> deduplicatePlugins(List<String> plugins) {
-        // Collect info for JAR files with Plugin-Id
         Map<String, List<PluginJarInfo>> byPluginId = new LinkedHashMap<String, List<PluginJarInfo>>();
-
         List<String> result = new ArrayList<String>();
 
         for (String jarPath : plugins) {
             PluginJarInfo info = readPluginJarInfo(jarPath);
-            if (info != null) {
-                for (String pluginId : info.pluginId) {
-                    byPluginId.computeIfAbsent(pluginId, k -> new ArrayList<>())
-                            .add(info);
-                }
-            } else if (!jarPath.endsWith(".jar")) {
-                // E.g. .class explicitly passed from the command line
+            if (info == null) {
+                // Carries no plugin: a .class explicitly passed on the command line, agent.jar,
+                // boot.jar, or a JAR whose manifest could not be read.
                 result.add(jarPath);
+                continue;
+            }
+            for (String pluginId : info.pluginIds) {
+                byPluginId.computeIfAbsent(pluginId, k -> new ArrayList<PluginJarInfo>())
+                        .add(info);
             }
         }
 
-        Set<String> problematicJars = new HashSet<>();
-        // Detect problematic jars: they have plugins with overlapping ids
+        // A JAR is loaded when it is the newest provider of every identity it declares, which keeps
+        // the decision consistent for a JAR that ships several plugins at once.
+        Set<String> displaced = new HashSet<>();
+        // One pair of duplicated JARs normally collides on several identities at once, for example
+        // on an explicit Plugin-Id and on the entry-point set. Repeating the same advice per
+        // identity would only bury it, so each set of JARs is reported once, under the first
+        // identity it collided on. That one reads best, since entry-point identities come last.
+        Set<List<String>> reported = new HashSet<>();
         String lib = new File(DumpRootResolverAgent.PROFILER_HOME).getAbsolutePath();
         for (Map.Entry<String, List<PluginJarInfo>> entry : byPluginId.entrySet()) {
             List<PluginJarInfo> jars = entry.getValue();
             if (jars.size() == 1) {
-                // If the plugin is included in a single jar only, add the jar to the resulting list
-                // It might be removed later if there's an overlap with another plugin id
-                if (!problematicJars.contains(jars.get(0).jarPath)) {
-                    result.add(jars.get(0).jarPath);
+                continue;
+            }
+            PluginJarInfo winner = jars.get(0);
+            List<String> jarPaths = new ArrayList<String>();
+            for (PluginJarInfo jar : jars) {
+                jarPaths.add(jar.jarPath);
+                if (compareVersions(jar.version, winner.version) > 0) {
+                    winner = jar;
                 }
-            } else {
-                // Duplicate Plugin-Id found, skip ALL of them and log warning
-                StringBuilder sb = new StringBuilder();
-                sb.append("Profiler: Duplicate Plugin-Id '").append(entry.getKey()).append("' found in multiple JARs. ");
-                sb.append("None of them will be loaded. Please remove the duplicate JAR(s):\n");
-                for (PluginJarInfo jar : jars) {
-                    if (problematicJars.add(jar.jarPath)) {
-                        // If the jar was n
-                        result.remove(jar.jarPath);
-                    }
-                    sb.append("  - ").append(jar.jarPath.replace(lib, "$esc"));
-                    if (jar.version != null) {
-                        sb.append(" (version=").append(jar.version).append(")");
-                    }
-                    sb.append("\n");
+            }
+            Collections.sort(jarPaths);
+            boolean firstReport = reported.add(jarPaths);
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("Profiler: plugin '").append(entry.getKey()).append("' is provided by several JARs. ")
+                    .append("Only the newest one is loaded; remove the stale file(s) listed below:\n");
+            for (PluginJarInfo jar : jars) {
+                sb.append("  - ").append(jar.jarPath.replace(lib, "$esc"));
+                if (jar.version != null) {
+                    sb.append(" (version=").append(jar.version).append(")");
                 }
+                if (jar == winner) {
+                    sb.append(" -- loaded\n");
+                } else {
+                    displaced.add(jar.jarPath);
+                    sb.append(" -- skipped\n");
+                }
+            }
+            if (firstReport) {
                 logger.warning(sb.toString());
+            } else {
+                logger.fine(sb.toString());
+            }
+        }
+
+        for (Map.Entry<String, List<PluginJarInfo>> entry : byPluginId.entrySet()) {
+            for (PluginJarInfo jar : entry.getValue()) {
+                if (!displaced.contains(jar.jarPath) && !result.contains(jar.jarPath)) {
+                    result.add(jar.jarPath);
+                }
             }
         }
         return result;
@@ -260,7 +357,7 @@ public class Bootstrap {
                         info("Profiler: loading " + jarName.replace(lib, "$esc"));
                         impls.addAll(loader.startPlugin());
                     } else if (!jarName.endsWith("agent.jar") && !jarName.endsWith("boot.jar")) {
-                        info("Profiler: jar " + jarName + " was skipped since it does not contain entry points");
+                        info("Profiler: jar " + jarName + " was not loaded as a plugin");
                     }
                 } else
                     logger.warning("Profiler: unknown argument " + jarName + ". Expecting *.class or *.jar");

--- a/boot/src/main/java/com/netcracker/profiler/agent/Bootstrap.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/Bootstrap.java
@@ -204,7 +204,10 @@ public class Bootstrap {
             Attributes attrs = man.getMainAttributes();
             String version = attrs.getValue("Implementation-Version");
             return new PluginJarInfo(jarPath, extractPluginIds(attrs), version);
-        } catch (IOException e) {
+        } catch (Throwable e) {
+            // Not only IOException: a SecurityManager that denies the read, or a signature check on
+            // a signed JAR, throws SecurityException from here. Anything that escapes would cost
+            // every other plugin, which is the outcome this classification exists to prevent.
             logger.log(Level.WARNING, "Profiler: unable to read the manifest of " + jarPath
                     + ", the file is skipped", e);
             return null;

--- a/boot/src/main/java/com/netcracker/profiler/agent/PluginClassLoader.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/PluginClassLoader.java
@@ -76,8 +76,13 @@ public class PluginClassLoader extends URLClassLoader {
         if ("instrumenter".equals(dependencies)) {
             ProfilerTransformerPlugin plugin = Bootstrap.getPlugin(ProfilerTransformerPlugin.class);
             if (plugin == null) {
-                logger.severe("Plugin " + jarName + " requires instrumenter, however it was not found on the classpath. Please ensure /lib/runtime.jar exists and can be loaded.");
-            } else parentLoader = plugin.getClass().getClassLoader();
+                // Loading the plugin anyway would only reach NoClassDefFoundError on its first
+                // class: everything it extends lives in the instrumenter.
+                logger.severe("Plugin " + jarName + " requires instrumenter, however it was not found on the classpath. " +
+                        "The plugin will not be loaded. Please ensure /lib/runtime.jar exists and can be loaded.");
+                return null;
+            }
+            parentLoader = plugin.getClass().getClassLoader();
         }
         return new PluginClassLoader(parentLoader, new URL[]{new File(jarName).toURI().toURL()}, entryPoints, preloadList);
     }

--- a/boot/src/main/java/com/netcracker/profiler/agent/PluginClassLoader.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/PluginClassLoader.java
@@ -89,9 +89,14 @@ public class PluginClassLoader extends URLClassLoader {
 
     private static Attributes getManifestAttributes(String jarName) throws IOException {
         final JarFile jar = new JarFile(jarName);
-        final Manifest manifest = jar.getManifest();
-        jar.close();
-        return manifest.getMainAttributes();
+        final Manifest manifest;
+        try {
+            manifest = jar.getManifest();
+        } finally {
+            jar.close();
+        }
+        // A JAR without a manifest declares no entry points, so it is not a plugin.
+        return manifest == null ? new Attributes() : manifest.getMainAttributes();
     }
 
     public List<Object> startPlugin() throws ClassNotFoundException, InvocationTargetException, IllegalAccessException, NoSuchMethodException, InstantiationException {

--- a/boot/src/main/java/com/netcracker/profiler/agent/Profiler.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/Profiler.java
@@ -27,14 +27,24 @@ public class Profiler {
         }
         enter("void " + Profiler.class.getName() + ".startDumper() (Profiler.java:20) [profiler-runtime.jar]");
 
-        dumper.newDumper(ProfilerData.dirtyBuffers, ProfilerData.emptyBuffers, ProfilerData.activeThreads);
-        ProfilerTransformerPlugin plugin = Bootstrap.getPlugin(ProfilerTransformerPlugin.class);
-
-        final ProfilerTransformerPlugin_01 transformerPlugin = (ProfilerTransformerPlugin_01) plugin;
         try {
-            transformerPlugin.reloadClasses(null);
-        } catch (IOException|SAXException|ParserConfigurationException e) {
-            logger.severe("[Profiler] Unable to reload bootstrap classes", e);
+            dumper.newDumper(ProfilerData.dirtyBuffers, ProfilerData.emptyBuffers, ProfilerData.activeThreads);
+            ProfilerTransformerPlugin plugin = Bootstrap.getPlugin(ProfilerTransformerPlugin.class);
+            if (plugin == null) {
+                logger.severe("[Profiler] Unable to find the profiling transformer in the class path");
+                return;
+            }
+            try {
+                ((ProfilerTransformerPlugin_01) plugin).reloadClasses(null);
+            } catch (IOException|SAXException|ParserConfigurationException e) {
+                logger.severe("[Profiler] Unable to reload bootstrap classes", e);
+            }
+        } catch (Throwable e) {
+            // Escaping here would fail Profiler's static initializer, so every later touch of the
+            // class, instrumented application code included, would throw NoClassDefFoundError. A
+            // half-initialized agent has to degrade to "no profiling", not to a broken class.
+            logger.severe("[Profiler] Unable to start the dumper, profiling data is not collected", e);
+            return;
         }
         exit(); // This is not in finally to ensure error message has better chances to be printed
     }

--- a/boot/src/main/java/com/netcracker/profiler/agent/Profiler.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/Profiler.java
@@ -25,14 +25,17 @@ public class Profiler {
             logger.severe("[Profiler] Unable to find Dumper in the class path", e);
             return;
         }
+        final LocalState state;
         try {
-            enter("void " + Profiler.class.getName() + ".startDumper() (Profiler.java:20) [profiler-runtime.jar]");
+            state = getState();
         } catch (Throwable e) {
-            logger.severe("[Profiler] Unable to open the dumper startup call, profiling data is not collected", e);
+            logger.severe("[Profiler] Unable to reach the profiler state, profiling data is not collected", e);
             return;
         }
+        int depthBeforeEnter = state.sp;
 
         try {
+            enter("void " + Profiler.class.getName() + ".startDumper() (Profiler.java:20) [profiler-runtime.jar]");
             dumper.newDumper(ProfilerData.dirtyBuffers, ProfilerData.emptyBuffers, ProfilerData.activeThreads);
             ProfilerTransformerPlugin plugin = Bootstrap.getPlugin(ProfilerTransformerPlugin.class);
             if (plugin == null) {
@@ -54,7 +57,15 @@ public class Profiler {
             // exit() has to pair with enter() on every path out. LocalState ends a call only when
             // its depth returns to zero, so a thread left one frame deep never writes another
             // completed call -- and this runs on whichever application thread touched Profiler first.
-            exit();
+            // The depth decides rather than the control flow: enter() can fail after opening the
+            // frame, and an exit() below the entry depth throws instead of unwinding.
+            try {
+                if (state.sp > depthBeforeEnter) {
+                    exit();
+                }
+            } catch (Throwable e) {
+                logger.severe("[Profiler] Unable to close the dumper startup call", e);
+            }
         }
     }
 

--- a/boot/src/main/java/com/netcracker/profiler/agent/Profiler.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/Profiler.java
@@ -25,28 +25,37 @@ public class Profiler {
             logger.severe("[Profiler] Unable to find Dumper in the class path", e);
             return;
         }
-        enter("void " + Profiler.class.getName() + ".startDumper() (Profiler.java:20) [profiler-runtime.jar]");
+        try {
+            enter("void " + Profiler.class.getName() + ".startDumper() (Profiler.java:20) [profiler-runtime.jar]");
+        } catch (Throwable e) {
+            logger.severe("[Profiler] Unable to open the dumper startup call, profiling data is not collected", e);
+            return;
+        }
 
         try {
             dumper.newDumper(ProfilerData.dirtyBuffers, ProfilerData.emptyBuffers, ProfilerData.activeThreads);
             ProfilerTransformerPlugin plugin = Bootstrap.getPlugin(ProfilerTransformerPlugin.class);
             if (plugin == null) {
                 logger.severe("[Profiler] Unable to find the profiling transformer in the class path");
-                return;
-            }
-            try {
-                ((ProfilerTransformerPlugin_01) plugin).reloadClasses(null);
-            } catch (IOException|SAXException|ParserConfigurationException e) {
-                logger.severe("[Profiler] Unable to reload bootstrap classes", e);
+            } else {
+                try {
+                    ((ProfilerTransformerPlugin_01) plugin).reloadClasses(null);
+                } catch (IOException|SAXException|ParserConfigurationException e) {
+                    logger.severe("[Profiler] Unable to reload bootstrap classes", e);
+                }
             }
         } catch (Throwable e) {
             // Escaping here would fail Profiler's static initializer, so every later touch of the
             // class, instrumented application code included, would throw NoClassDefFoundError. A
             // half-initialized agent has to degrade to "no profiling", not to a broken class.
+            // The message is logged here rather than after exit() so it survives a failing exit().
             logger.severe("[Profiler] Unable to start the dumper, profiling data is not collected", e);
-            return;
+        } finally {
+            // exit() has to pair with enter() on every path out. LocalState ends a call only when
+            // its depth returns to zero, so a thread left one frame deep never writes another
+            // completed call -- and this runs on whichever application thread touched Profiler first.
+            exit();
         }
-        exit(); // This is not in finally to ensure error message has better chances to be printed
     }
 
     public static LocalState getState() {

--- a/boot/src/test/java/com/netcracker/profiler/agent/BootstrapTest.java
+++ b/boot/src/test/java/com/netcracker/profiler/agent/BootstrapTest.java
@@ -157,6 +157,19 @@ public class BootstrapTest {
     }
 
     @Test
+    void compareVersions_numericSegmentOutranksAQualifier() {
+        assertTrue(Bootstrap.compareVersions("4.0.5.1", "4.0.5-SNAPSHOT") > 0);
+        assertTrue(Bootstrap.compareVersions("4.0.5-SNAPSHOT", "4.0.5.1") < 0);
+        assertTrue(Bootstrap.compareVersions("4.0.5-2", "4.0.5-rc1") > 0);
+    }
+
+    @Test
+    void compareVersions_qualifierDoesNotOutrankALaterRelease() {
+        assertTrue(Bootstrap.compareVersions("4.0.5-SNAPSHOT", "4.0.6") < 0);
+        assertTrue(Bootstrap.compareVersions("4.0.6", "4.0.5-SNAPSHOT") > 0);
+    }
+
+    @Test
     void compareVersions_missingVersionLosesToAnyVersion() {
         assertTrue(Bootstrap.compareVersions(null, "1.0") < 0);
         assertTrue(Bootstrap.compareVersions("1.0", null) > 0);

--- a/boot/src/test/java/com/netcracker/profiler/agent/BootstrapTest.java
+++ b/boot/src/test/java/com/netcracker/profiler/agent/BootstrapTest.java
@@ -91,10 +91,11 @@ public class BootstrapTest {
     /**
      * The runtime JAR predating {@code Plugin-Id} must land on the same identity as the release that
      * introduced the attribute, otherwise a stale copy loads next to the current one and every
-     * enhancer fails to cast — see issue #412.
+     * enhancer fails to cast — see issue #412. The shared identity has to be the entry-point set:
+     * that is the only thing the two manifests have in common.
      */
     @Test
-    void extractPluginIds_entryPointSetIsSharedAcrossReleases() {
+    void extractPluginIds_entryPointSetSurvivesTheAbsenceOfPluginId() {
         String entryPoints = "com.netcracker.profiler.agent.plugins.EnhancerRegistryPluginImpl "
                 + "com.netcracker.profiler.agent.plugins.ProfilerTransformerPluginImpl "
                 + "com.netcracker.profiler.agent.plugins.DumperPluginImpl";
@@ -102,8 +103,15 @@ public class BootstrapTest {
         Set<String> withAttribute =
                 Bootstrap.extractPluginIds(manifest("Plugin-Id", "profiler-runtime", "Entry-Points", entryPoints));
 
-        assertFalse(Collections.disjoint(withoutAttribute, withAttribute),
-                "Expected a shared plugin identity between " + withoutAttribute + " and " + withAttribute);
+        Set<String> shared = new LinkedHashSet<>(withoutAttribute);
+        shared.retainAll(withAttribute);
+        assertEquals(
+                ids("entry-points:com.netcracker.profiler.agent.plugins.DumperPluginImpl "
+                        + "com.netcracker.profiler.agent.plugins.EnhancerRegistryPluginImpl "
+                        + "com.netcracker.profiler.agent.plugins.ProfilerTransformerPluginImpl"),
+                shared,
+                "Expected the entry-point set to be the identity shared by " + withoutAttribute
+                        + " and " + withAttribute);
     }
 
     @Test

--- a/boot/src/test/java/com/netcracker/profiler/agent/BootstrapTest.java
+++ b/boot/src/test/java/com/netcracker/profiler/agent/BootstrapTest.java
@@ -6,60 +6,152 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.jar.Attributes;
 
 public class BootstrapTest {
-    @Test
-    void extractPluginId_fromExplicitAttribute() {
+    private static Attributes manifest(String... keysAndValues) {
         Attributes attrs = new Attributes();
-        attrs.putValue("Plugin-Id", "spring");
-        assertEquals(Collections.singletonList("spring"), Bootstrap.extractPluginId(attrs));
+        for (int i = 0; i < keysAndValues.length; i += 2) {
+            attrs.putValue(keysAndValues[i], keysAndValues[i + 1]);
+        }
+        return attrs;
+    }
+
+    private static Set<String> ids(String... values) {
+        return new LinkedHashSet<>(Arrays.asList(values));
     }
 
     @Test
-    void extractPluginId_fromEntryPoints() {
-        Attributes attrs = new Attributes();
-        attrs.putValue("Entry-Points", "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_spring");
-        assertEquals(Collections.singletonList("spring"), Bootstrap.extractPluginId(attrs));
+    void extractPluginIds_fromExplicitAttribute() {
+        assertEquals(
+                ids("spring", "entry-points:com.example.SpringPlugin"),
+                Bootstrap.extractPluginIds(
+                        manifest("Plugin-Id", "spring", "Entry-Points", "com.example.SpringPlugin")));
     }
 
     @Test
-    void extractPluginId_preferExplicitOverEntryPoints() {
-        Attributes attrs = new Attributes();
-        attrs.putValue("Plugin-Id", "explicit-id");
-        attrs.putValue("Entry-Points", "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_fallback");
-        assertEquals(Collections.singletonList("explicit-id"), Bootstrap.extractPluginId(attrs));
+    void extractPluginIds_fromEntryPoints() {
+        assertEquals(
+                ids(
+                        "spring",
+                        "entry-points:com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_spring"),
+                Bootstrap.extractPluginIds(
+                        manifest(
+                                "Entry-Points",
+                                "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_spring")));
     }
 
     @Test
-    void extractPluginId_multipleEntryPoints() {
-        Attributes attrs = new Attributes();
-        attrs.putValue("Entry-Points", "com.example.Other com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_jdbc");
-        assertEquals(Collections.singletonList("jdbc"), Bootstrap.extractPluginId(attrs));
+    void extractPluginIds_explicitAndEntryPointsAreBothIdentities() {
+        assertEquals(
+                ids(
+                        "explicit-id",
+                        "fallback",
+                        "entry-points:com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_fallback"),
+                Bootstrap.extractPluginIds(
+                        manifest(
+                                "Plugin-Id", "explicit-id",
+                                "Entry-Points",
+                                "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_fallback")));
     }
 
     @Test
-    void extractPluginId_multipleEntryPoints2() {
-        Attributes attrs = new Attributes();
-        attrs.putValue("Entry-Points", "com.example.Other com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_jdbc com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_spring");
-        assertEquals(Arrays.asList("jdbc", "spring"), Bootstrap.extractPluginId(attrs));
+    void extractPluginIds_multipleEntryPoints() {
+        assertEquals(
+                ids(
+                        "jdbc",
+                        "entry-points:com.example.Other "
+                                + "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_jdbc"),
+                Bootstrap.extractPluginIds(
+                        manifest(
+                                "Entry-Points",
+                                "com.example.Other "
+                                        + "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_jdbc")));
     }
 
     @Test
-    void extractPluginId_noPluginId() {
-        Attributes attrs = new Attributes();
-        attrs.putValue("Entry-Points", "com.example.SomeOtherClass");
-        assertEquals(Collections.emptyList(), Bootstrap.extractPluginId(attrs));
+    void extractPluginIds_multipleEnhancers() {
+        assertEquals(
+                ids(
+                        "jdbc",
+                        "spring",
+                        "entry-points:com.example.Other "
+                                + "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_jdbc "
+                                + "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_spring"),
+                Bootstrap.extractPluginIds(
+                        manifest(
+                                "Entry-Points",
+                                "com.example.Other "
+                                        + "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_jdbc "
+                                        + "com.netcracker.profiler.instrument.enhancement.EnhancerPlugin_spring")));
+    }
+
+    /**
+     * The runtime JAR predating {@code Plugin-Id} must land on the same identity as the release that
+     * introduced the attribute, otherwise a stale copy loads next to the current one and every
+     * enhancer fails to cast — see issue #412.
+     */
+    @Test
+    void extractPluginIds_entryPointSetIsSharedAcrossReleases() {
+        String entryPoints = "com.netcracker.profiler.agent.plugins.EnhancerRegistryPluginImpl "
+                + "com.netcracker.profiler.agent.plugins.ProfilerTransformerPluginImpl "
+                + "com.netcracker.profiler.agent.plugins.DumperPluginImpl";
+        Set<String> withoutAttribute = Bootstrap.extractPluginIds(manifest("Entry-Points", entryPoints));
+        Set<String> withAttribute =
+                Bootstrap.extractPluginIds(manifest("Plugin-Id", "profiler-runtime", "Entry-Points", entryPoints));
+
+        assertFalse(Collections.disjoint(withoutAttribute, withAttribute),
+                "Expected a shared plugin identity between " + withoutAttribute + " and " + withAttribute);
     }
 
     @Test
-    void extractPluginId_nullAttributes() {
-        assertEquals(Collections.emptyList(), Bootstrap.extractPluginId(null));
+    void extractPluginIds_entryPointOrderDoesNotMatter() {
+        assertEquals(
+                Bootstrap.extractPluginIds(manifest("Entry-Points", "com.example.A com.example.B")),
+                Bootstrap.extractPluginIds(manifest("Entry-Points", "com.example.B com.example.A")));
     }
 
     @Test
-    void extractPluginId_emptyAttributes() {
-        Attributes attrs = new Attributes();
-        assertEquals(Collections.emptyList(), Bootstrap.extractPluginId(attrs));
+    void extractPluginIds_noEntryPoints() {
+        assertEquals(Collections.emptySet(), Bootstrap.extractPluginIds(manifest("Plugin-Id", "spring")));
+    }
+
+    @Test
+    void extractPluginIds_nullAttributes() {
+        assertEquals(Collections.emptySet(), Bootstrap.extractPluginIds(null));
+    }
+
+    @Test
+    void extractPluginIds_emptyAttributes() {
+        assertEquals(Collections.emptySet(), Bootstrap.extractPluginIds(new Attributes()));
+    }
+
+    @Test
+    void compareVersions_numericSegments() {
+        assertTrue(Bootstrap.compareVersions("4.0.5", "3.0.6") > 0);
+        assertTrue(Bootstrap.compareVersions("3.0.6", "4.0.5") < 0);
+        assertTrue(Bootstrap.compareVersions("4.0.10", "4.0.9") > 0);
+        assertEquals(0, Bootstrap.compareVersions("4.0.5", "4.0.5"));
+    }
+
+    @Test
+    void compareVersions_shorterVersionLosesToLongerNumericOne() {
+        assertTrue(Bootstrap.compareVersions("4.0", "4.0.1") < 0);
+        assertTrue(Bootstrap.compareVersions("4.0.1", "4.0") > 0);
+    }
+
+    @Test
+    void compareVersions_qualifierLosesToTheRelease() {
+        assertTrue(Bootstrap.compareVersions("4.0.5-SNAPSHOT", "4.0.5") < 0);
+        assertTrue(Bootstrap.compareVersions("4.0.5", "4.0.5-SNAPSHOT") > 0);
+    }
+
+    @Test
+    void compareVersions_missingVersionLosesToAnyVersion() {
+        assertTrue(Bootstrap.compareVersions(null, "1.0") < 0);
+        assertTrue(Bootstrap.compareVersions("1.0", null) > 0);
+        assertEquals(0, Bootstrap.compareVersions(null, null));
     }
 }

--- a/installer/src/test/kotlin/com/netcracker/profiler/test/agent/AgentStartupResilienceTest.kt
+++ b/installer/src/test/kotlin/com/netcracker/profiler/test/agent/AgentStartupResilienceTest.kt
@@ -1,0 +1,132 @@
+package com.netcracker.profiler.test.agent
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy
+import org.testcontainers.images.builder.Transferable
+import org.testcontainers.utility.MountableFile
+import java.io.ByteArrayOutputStream
+import java.time.Duration
+import java.util.Objects
+import java.util.jar.Attributes
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+
+/**
+ * libinstrument aborts the JVM on any exception leaving `premain`, so a profiler that cannot start
+ * itself takes the application down with it. These tests reproduce the two ways `/app/diag/lib`
+ * goes wrong in the field, and require the application to run regardless.
+ *
+ * See [issue #412](https://github.com/Netcracker/qubership-profiler-agent/issues/412): a stale copy
+ * of the runtime JAR next to the current one gave each copy its own `PluginClassLoader`, every
+ * enhancer then failed to cast to the `EnhancerPlugin` of the other copy, and the service died with
+ * `FATAL ERROR in native method: processing of -javaagent failed`.
+ */
+class AgentStartupResilienceTest {
+    companion object {
+        private val TESTAPP_JAR: String = Objects.requireNonNull(
+            System.getProperty("qubership.profiler.testapp.jar"),
+            "system property qubership.profiler.testapp.jar"
+        )
+
+        private val CORE_BASE_IMAGE_TAG: String = Objects.requireNonNull(
+            System.getProperty("qubership.profiler.java-base-image.tag"),
+            "system property qubership.profiler.java-base-image.tag"
+        )
+
+        private const val LIB = "/app/diag/lib"
+
+        /** Printed by the test application once it is running under the agent. */
+        private const val APPLICATION_STARTED = "hello, world!"
+    }
+
+    @Test
+    fun `application starts when lib holds a stale copy of the runtime jar`() {
+        val container = testApplication("[stale-runtime] ")
+            // A rebased image, an init container, or a mount can leave an older runtime JAR behind.
+            // Copying the current one reproduces that without pinning the test to a past release.
+            .withCommand(
+                "sh", "-c",
+                "cp $LIB/qubership-profiler-runtime.jar $LIB/stale-runtime.jar && " +
+                    "exec java -jar /app/testapp.jar 1"
+            )
+
+        val logs = container.use {
+            it.start()
+            it.logs
+        }
+
+        assertApplicationRan(logs, "a duplicated runtime JAR in $LIB")
+        assertTrue(logs.contains("is provided by several JARs")) {
+            "Expected the duplicated runtime JAR to be reported.\n\n$logs"
+        }
+        // Dropping every copy would leave the service unprofiled, which is what the duplicate
+        // warning is meant to prevent -- the newest copy has to stay.
+        assertTrue(logs.contains("Profiler: initialized, version")) {
+            "Expected the profiler to keep working on the surviving runtime JAR.\n\n$logs"
+        }
+    }
+
+    @Test
+    fun `application starts when a plugin jar cannot be loaded`() {
+        val container = testApplication("[broken-plugin] ")
+            .withCopyToContainer(Transferable.of(brokenPluginJar()), "$LIB/broken-plugin.jar")
+            .withCommand("java", "-jar", "/app/testapp.jar", "1")
+
+        val logs = container.use {
+            it.start()
+            it.logs
+        }
+
+        assertApplicationRan(logs, "an unloadable plugin JAR in $LIB")
+        // This also keeps the scenario honest: a plugin dropped unread would leave the agent
+        // healthy, and the test would stop exercising the premain boundary it was written for.
+        assertTrue(logs.contains("the application continues without profiling")) {
+            "Expected the agent to load the broken plugin and then give up on profiling.\n\n$logs"
+        }
+    }
+
+    private fun assertApplicationRan(logs: String, scenario: String) {
+        assertTrue(logs.contains(APPLICATION_STARTED)) {
+            "The application did not start with $scenario.\n\n$logs"
+        }
+        // libinstrument aborts the JVM on any exception leaving premain, and the entrypoint keeps
+        // going afterwards, so the abort has to be caught in the log rather than in the exit code.
+        assertTrue(!logs.contains("processing of -javaagent failed")) {
+            "The agent aborted the JVM with $scenario.\n\n$logs"
+        }
+    }
+
+    /**
+     * A one-shot run of the test application under the base image, so that `start()` fails unless
+     * the JVM ran the application to completion and exited with 0.
+     */
+    private fun testApplication(logPrefix: String): GenericContainer<*> =
+        GenericContainer(CORE_BASE_IMAGE_TAG)
+            .withEnv("ESC_LOG_LEVEL", "debug")
+            .withEnv("PROFILER_ENABLED", "true")
+            .withEnv("NC_DIAGNOSTIC_MODE", "prod")
+            .withEnv("CLOUD_NAMESPACE", "test-namespace")
+            .withEnv("MICROSERVICE_NAME", "test-app")
+            .withCopyToContainer(MountableFile.forHostPath(TESTAPP_JAR), "/app/testapp.jar")
+            .withStartupAttempts(1)
+            .withStartupTimeout(Duration.ofMinutes(2))
+            .withLogConsumer(LogToConsolePrinter(logPrefix))
+            .withStartupCheckStrategy(OneShotStartupCheckStrategy())
+
+    /**
+     * A manifest-only JAR whose single entry point does not exist, which is the cheapest way to make
+     * plugin loading throw.
+     */
+    private fun brokenPluginJar(): ByteArray {
+        val manifest = Manifest().apply {
+            mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+            mainAttributes.putValue("Entry-Points", "com.example.MissingPlugin")
+            mainAttributes.putValue("Implementation-Version", "9.9.9")
+        }
+        val jar = ByteArrayOutputStream()
+        JarOutputStream(jar, manifest).close()
+        return jar.toByteArray()
+    }
+}

--- a/installer/src/test/kotlin/com/netcracker/profiler/test/agent/AgentStartupResilienceTest.kt
+++ b/installer/src/test/kotlin/com/netcracker/profiler/test/agent/AgentStartupResilienceTest.kt
@@ -10,6 +10,7 @@ import java.io.ByteArrayOutputStream
 import java.time.Duration
 import java.util.Objects
 import java.util.jar.Attributes
+import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
 
@@ -88,12 +89,18 @@ class AgentStartupResilienceTest {
     }
 
     @Test
-    fun `profiling survives an unreadable file in lib`() {
+    fun `profiling survives files in lib that cannot be read`() {
         val container = testApplication("[corrupt-jar] ")
-            // A half-finished copy or a truncated download lands here as a file the JAR reader
-            // cannot open at all, which is a different case from a JAR that merely fails to load.
+            // Two shapes of damage, because the agent used to classify with one reader and load
+            // with another. A file that is not a ZIP fails both; a JAR cut off before its central
+            // directory still yields a manifest to a streaming reader, and only fails the
+            // random-access one the loader uses.
             .withCopyToContainer(
                 Transferable.of("this is not a JAR"),
+                "$LIB/qubership-profiler-plugins-garbage.jar"
+            )
+            .withCopyToContainer(
+                Transferable.of(truncatedJar()),
                 "$LIB/qubership-profiler-plugins-truncated.jar"
             )
             .withCommand("java", "-jar", "/app/testapp.jar", "1")
@@ -103,10 +110,10 @@ class AgentStartupResilienceTest {
             it.logs
         }
 
-        assertApplicationRan(logs, "an unreadable file in $LIB")
-        // One stray file must cost the plugin it is, not the whole agent.
+        assertApplicationRan(logs, "unreadable files in $LIB")
+        // A stray file must cost the plugin it is, not the whole agent.
         assertTrue(logs.contains("Profiler: initialized, version")) {
-            "Expected the profiler to keep loading around the unreadable file.\n\n$logs"
+            "Expected the profiler to keep loading around the unreadable files.\n\n$logs"
         }
     }
 
@@ -151,5 +158,33 @@ class AgentStartupResilienceTest {
         val jar = ByteArrayOutputStream()
         JarOutputStream(jar, manifest).close()
         return jar.toByteArray()
+    }
+
+    /**
+     * A JAR cut off partway through its payload: the manifest is intact at the front, and the
+     * central directory a random-access reader needs is gone from the tail. It declares no entry
+     * points, so it is the case that used to be classified "intact, not a plugin" and handed to the
+     * loader, which then failed on it and took every other plugin down.
+     */
+    private fun truncatedJar(): ByteArray {
+        val manifest = Manifest().apply {
+            mainAttributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+            mainAttributes.putValue("Implementation-Version", "9.9.9")
+        }
+        val jar = ByteArrayOutputStream()
+        JarOutputStream(jar, manifest).use { out ->
+            out.putNextEntry(JarEntry("payload.bin"))
+            // Incompressible, so the cut below lands inside the payload instead of past its end.
+            val payload = ByteArray(256 * 1024)
+            var seed = 1L
+            for (i in payload.indices) {
+                seed = seed * 6364136223846793005L + 1442695040888963407L
+                payload[i] = (seed ushr 33).toByte()
+            }
+            out.write(payload)
+            out.closeEntry()
+        }
+        val bytes = jar.toByteArray()
+        return bytes.copyOf(bytes.size / 2)
     }
 }

--- a/installer/src/test/kotlin/com/netcracker/profiler/test/agent/AgentStartupResilienceTest.kt
+++ b/installer/src/test/kotlin/com/netcracker/profiler/test/agent/AgentStartupResilienceTest.kt
@@ -87,6 +87,29 @@ class AgentStartupResilienceTest {
         }
     }
 
+    @Test
+    fun `profiling survives an unreadable file in lib`() {
+        val container = testApplication("[corrupt-jar] ")
+            // A half-finished copy or a truncated download lands here as a file the JAR reader
+            // cannot open at all, which is a different case from a JAR that merely fails to load.
+            .withCopyToContainer(
+                Transferable.of("this is not a JAR"),
+                "$LIB/qubership-profiler-plugins-truncated.jar"
+            )
+            .withCommand("java", "-jar", "/app/testapp.jar", "1")
+
+        val logs = container.use {
+            it.start()
+            it.logs
+        }
+
+        assertApplicationRan(logs, "an unreadable file in $LIB")
+        // One stray file must cost the plugin it is, not the whole agent.
+        assertTrue(logs.contains("Profiler: initialized, version")) {
+            "Expected the profiler to keep loading around the unreadable file.\n\n$logs"
+        }
+    }
+
     private fun assertApplicationRan(logs: String, scenario: String) {
         assertTrue(logs.contains(APPLICATION_STARTED)) {
             "The application did not start with $scenario.\n\n$logs"


### PR DESCRIPTION
## Why

A stale copy of the runtime JAR next to the current one in `/app/diag/lib` gave each copy its own `PluginClassLoader`. Every `EnhancerPlugin_*` then failed to cast to the `EnhancerPlugin` of the other copy, the exception left `premain`, and libinstrument aborted the JVM with `processing of -javaagent failed` — the service never ran a line of its own. Reported in #412 against 3.0.6 for core-operator and config-server.

Reproduced locally against the released 3.0.6 installer with a second copy of `qubership-profiler-runtime.jar` in `lib/`: the same `ClassCastException` between two `PluginClassLoader` instances, the same fatal abort, exit code 134.

The duplicate detection added in 90267ed8 does not close this. Rebuilt with it, the same scenario still aborts the JVM: dropping every copy of the runtime leaves the plugins that depend on the instrumenter to fail with `NoClassDefFoundError`, which is fatal in exactly the same way.

## What

- `premain` catches every startup failure and logs it, so the application keeps running unprofiled instead of dying. This is the part that closes the issue; the rest keeps the agent from reaching that state.
- Duplicate detection keeps the newest copy of a plugin instead of dropping all of them, so one stray file no longer leaves a service silently unprofiled.
- A JAR is identified by its entry-point set as well as by `Plugin-Id`, so a copy predating the `Plugin-Id` attribute is recognized as the same plugin. JARs carrying no plugin are no longer dropped unread.
- A plugin that needs the instrumenter is skipped when the instrumenter is missing, rather than loaded into a guaranteed `NoClassDefFoundError`.
- A dumper that fails to start no longer poisons `Profiler`'s static initializer, which otherwise killed the application at its first touch of the class.

The duplicate is still reported, now naming which file was loaded and which were skipped:

```text
WARNING Profiler: plugin 'profiler-runtime' is provided by several JARs. Only the newest one is loaded; remove the stale file(s) listed below:
  - $esc/lib/qubership-profiler-runtime.jar (version=4.0.5-SNAPSHOT) -- loaded
  - $esc/lib/stale-runtime.jar (version=3.0.6) -- skipped
```

## How to verify

`installer/src/test/kotlin/com/netcracker/profiler/test/agent/AgentStartupResilienceTest.kt` runs the test application on the base image under two broken `/app/diag/lib` layouts — a duplicated runtime JAR, and a plugin JAR whose entry point does not exist — and requires the application to run in both. Both assert that `processing of -javaagent failed` never reaches the log; the exit code cannot carry that, since the entrypoint swallows it.

```bash
./gradlew :installer:test --tests 'com.netcracker.profiler.test.agent.AgentStartupResilienceTest'
```

Both tests fail on `main`: the duplicate-runtime case with `Container did not start correctly`, the broken-plugin case on the assertion that the agent reported giving up.

`BootstrapTest` covers the new plugin identities and the version comparison. Green: `:boot:test`, `:installer:test`, `:installer-zip-test:test`, checkstyle and autostyle.

## Follow-up

What puts a second runtime JAR into `/app/diag/lib` in the reporter's deployment is still unknown — the released 3.0.6 installer contains exactly one. This change makes the situation non-fatal whatever the source, but `ls -la /app/diag/lib` from a failing pod would be worth having on #412.

Fixes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)
