### PR TITLE
fix(ci): validate npm lock file

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: backend/apps/ui/package-lock.json
       # One `go test ./...` from the module root covers apps/**, libs/** and
@@ -122,6 +122,17 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: diagtools/go.mod
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: backend/apps/ui/package-lock.json
+      - name: Validate UI lock file
+        # This required Test check catches package.json/lockfile drift before merge;
+        # the non-required coverage job installs the same lock file later.
+        working-directory: backend/apps/ui
+        run: npm ci --dry-run --no-audit --no-fund
       - name: Setup Zig
         # Zig is used as the cgo C compiler for cross-compiling diagtools
         # (linux/amd64, linux/arm64, windows/amd64) — see diagtools/Makefile.


### PR DESCRIPTION
# Pull Request

## Describe Your Changes

`main` already contains the lock-file repair from the earlier dependency PRs. This branch is rebased onto that version and keeps the useful required-check protection: the required `Test` job runs `npm ci --dry-run` against `backend/apps/ui/package.json` and `package-lock.json`, so dependency drift fails before merge.

The UI build policy uses Node.js 24 in both the required `Test` job and the non-required coverage job, matching `backend/apps/profiler-backend/Dockerfile`'s `node:24-alpine` builder image. The required check uses the npm cache keyed by the UI lock file. The coverage job still performs the full install and UI tests; it is not a required check, so the dry run remains the merge gate. The step comment documents why a Gradle job validates the UI lock file.

This check detects lock-file drift; preventing two individually green PRs from combining into a broken `main` still requires a strict required-check ruleset or merge queue, which is outside this PR.

Refs #906.

## How to verify

- Run `npm ci --no-audit --no-fund` in `backend/apps/ui`.
- Run `npm test` and `npm run build` in `backend/apps/ui`.
- Run `npm ci --dry-run --no-audit --no-fund` in `backend/apps/ui`.
- Run `actionlint .github/workflows/build.yaml`.

## Checklist

* [x] My change adheres [Qubership contributing guidelines](../CONTRIBUTING.md).
