### PR TITLE
fix(e2e): bound the flaky calls-table assertion instead of an exact match

### DIFF
--- a/it-e2e/e2e/calls-table.spec.ts
+++ b/it-e2e/e2e/calls-table.spec.ts
@@ -1,5 +1,25 @@
 import { test, expect } from './fixtures.js';
 
+/**
+ * Iterations the test app runs, passed as its last container argument in `it-e2e/build.gradle.kts`. Keep both in sync.
+ */
+const WORKLOAD_ITERATIONS = 10;
+
+/**
+ * Calls the workload always produces: `Main.doWork` plus one `Main.test` per iteration. `Main.test` is guaranteed
+ * because `it-e2e/config/_config.xml` attaches a `main.test.arg` parameter to it, and logging a parameter flushes the
+ * pending entry into the trace however short the call was.
+ */
+const WORKLOAD_CALLS = 1 + WORKLOAD_ITERATIONS;
+
+/**
+ * Headroom for JDK calls instrumented by `installer/src/main/resources/config/minimal/50main/java.xml`. The agent
+ * logs a nested call only when it spans a millisecond (`ProfilerData.MINIMAL_LOGGED_DURATION`), so how many of them
+ * reach the trace varies between runs. `Main.doWork` reaches two: the `java.io.FileOutputStream.write` behind each of
+ * its two `System.out.println` calls. The third slot is headroom for a JDK that routes stdout differently.
+ */
+const INCIDENTAL_CALL_ALLOWANCE = 3;
+
 test('profiler UI shows test-app method calls', async ({ page }) => {
   await page.goto('/');
 
@@ -22,10 +42,22 @@ test('profiler UI shows test-app method calls', async ({ page }) => {
   const durationMs = parseDuration(durationText!);
   expect(durationMs, `Expected duration > 5000ms, got ${durationText}`).toBeGreaterThan(5_000);
 
-  // Main.doWork now includes 10 instrumented Main.test child calls
+  // The Calls column counts every instrumented entry inside the call tree, application code and JDK alike, so the
+  // count is a range: the workload calls are guaranteed, the incidental JDK ones depend on how long they ran.
   const callsText = await cell('calls').textContent();
   const calls = parseInt(callsText!.trim(), 10);
-  expect(calls, `Expected calls = 12, got ${callsText}`).toBe(12);
+  const callsMessage =
+    `Expected ${WORKLOAD_CALLS}..${WORKLOAD_CALLS + INCIDENTAL_CALL_ALLOWANCE} calls ` +
+    `(Main.doWork + ${WORKLOAD_ITERATIONS} Main.test + incidental JDK calls), got ${callsText}`;
+  expect(calls, callsMessage).toBeGreaterThanOrEqual(WORKLOAD_CALLS);
+  expect(calls, callsMessage).toBeLessThanOrEqual(WORKLOAD_CALLS + INCIDENTAL_CALL_ALLOWANCE);
+
+  // JDK-level instrumentation gets its own assertion rather than riding on the call count. The byte counter runs as
+  // an `execute-before` hook, so both `System.out.println` payloads are counted even when neither write is logged as
+  // a call of its own.
+  const fileIoText = await cell('fileio').textContent();
+  const fileIoBytes = parseBytes(fileIoText!);
+  expect(fileIoBytes, `Expected non-zero Disk IO for Main.doWork, got ${fileIoText}`).toBeGreaterThan(0);
 
   // Transactions should be 0
   await expect(cell('txs')).toHaveText('0');
@@ -39,4 +71,12 @@ function parseDuration(text: string): number {
   const sec = text.match(/([\d.]+)s/);
   if (sec) return parseFloat(sec[1]) * 1000;
   throw new Error(`Cannot parse duration: ${text}`);
+}
+
+/** Parse an IO cell like "72 B", "3 KB" or "5 MiB" into bytes. */
+function parseBytes(text: string): number {
+  const match = text.trim().match(/^(\d+)\s*([KMG]?)i?B$/);
+  if (!match) throw new Error(`Cannot parse byte count: ${text}`);
+  const scale: Record<string, number> = { '': 1, K: 1024, M: 1024 ** 2, G: 1024 ** 3 };
+  return parseInt(match[1], 10) * scale[match[2]];
 }


### PR DESCRIPTION
## Why

`it-e2e/e2e/calls-table.spec.ts` asserted that the `Calls` cell of the `Main.doWork` row equals exactly 12. The workload guarantees only 11 of those calls: `Main.doWork` plus one `Main.test` per iteration, each forced into the trace because `it-e2e/config/_config.xml` attaches a `main.test.arg` parameter to it. The 12th call is an incidental JDK `FileOutputStream.write` behind one of the two `System.out.println` calls in `Main.doWork` — the agent only logs a nested call when it spans a millisecond (`ProfilerData.MINIMAL_LOGGED_DURATION`), so whether that write crosses the floor varies between runs. On a loaded CI runner both writes can cross it, and the cell reads 13, which is what failed PR #466 even though that change touched neither the agent nor the test app. The count is not double counting — it is a real extra call — so the fix belongs in the assertion, not in the profiler.

## What

- Replaced the exact `toBe(12)` assertion with a bounded range, derived from named constants instead of magic numbers: `WORKLOAD_ITERATIONS` (10, tracking the iteration count in `it-e2e/build.gradle.kts:94`), `WORKLOAD_CALLS` (`1 + WORKLOAD_ITERATIONS`, the guaranteed floor), and `INCIDENTAL_CALL_ALLOWANCE` (3, headroom above the two JDK calls `Main.doWork` can reach). The assertion now checks `calls` falls between `WORKLOAD_CALLS` and `WORKLOAD_CALLS + INCIDENTAL_CALL_ALLOWANCE`.
- Added a direct assertion on JDK-level instrumentation instead of leaning on the call count for it: the `fileio` cell must be non-zero. `IOCounters.fileWritten` runs as an `execute-before` hook on every `println`, so both payloads are counted even when only one write is logged as a call — this stays deterministic where the call count does not.
- Made the failure message name the bounds and their sources by interpolating the constants, so it stays diagnosable if the constants are tuned later.
- Replaced the stale comment above the assertion with one that states what the `Calls` column actually counts: every instrumented entry inside the call tree, application or JDK.

No product code changed. The agent, dumper, parsers, and UI all behave correctly; only the test's expectation was wrong.

## How to verify

- `./gradlew --quiet :it-e2e:e2eTest` — runs `generateTestDump` (requires Docker) and the Playwright specs against a freshly generated dump. `profiler UI shows test-app method calls` passes with the observed count of 12 and a non-zero Disk IO cell.
- To confirm the lower bound actually bites: temporarily set `WORKLOAD_ITERATIONS` to 12 and rerun the spec — it fails with the new message. Revert afterward.
- To confirm the Disk IO assertion bites: temporarily comment out the two `System.out.println` calls in `Main.doWork` and rerun — the cell goes empty and the new assertion fails while the call count stays inside the band. Revert afterward.
- `generateTestDump` declares `outputs.upToDateWhen { false }`, so each rerun regenerates the dump and exercises a fresh JVM run.

Fixes #767

This branch was produced by the autonomous issue pipeline and is opened as a draft for human review.
