### PR TITLE
ci: authenticate Codecov uploads with CODECOV_TOKEN

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,9 +9,9 @@ on:
       - '**'
 
 # Every job here only reads the repository: checkout, the language toolchains,
-# Gradle, and the Codecov uploads, which authenticate tokenlessly rather than
-# through OIDC. upload-artifact needs no scope of its own, since v4 and later
-# authenticate against the artifact service with the Actions runtime token.
+# Gradle, and the Codecov uploads, which authenticate with CODECOV_TOKEN rather
+# than through OIDC. upload-artifact needs no scope of its own, since v4 and
+# later authenticate against the artifact service with the Actions runtime token.
 permissions:
   contents: read
 
@@ -73,13 +73,14 @@ jobs:
         working-directory: backend/apps/ui
         # language=bash
         run: npm run test:coverage
-      # No token on any of the uploads. This repository is public, so Codecov
-      # accepts them over its tokenless path, and that path is the only one a
-      # pull request from a fork can use anyway: GitHub withholds secrets from
-      # those runs. Add CODECOV_TOKEN only if tokenless starts being rejected.
+      # Codecov refuses a tokenless upload once the branch is protected, so
+      # CODECOV_TOKEN is what keeps these steps green. A pull request from a fork
+      # sees an empty token, because GitHub withholds secrets from those runs;
+      # a tokenless upload from a public repository is still accepted there.
       - name: Upload Go coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # zizmor: ignore[secrets-outside-env]
           files: backend/coverage.out,diagtools/coverage.out
           flags: go
           disable_search: true
@@ -87,6 +88,7 @@ jobs:
       - name: Upload UI coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # zizmor: ignore[secrets-outside-env]
           files: backend/apps/ui/coverage/lcov.info
           flags: ui
           disable_search: true
@@ -134,6 +136,7 @@ jobs:
       - name: Upload Java coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # zizmor: ignore[secrets-outside-env]
           files: build/reports/jacoco/jacocoReport/jacocoReport.xml
           flags: java
           disable_search: true


### PR DESCRIPTION
## Why

The Codecov uploads added in #901 send no token, and Codecov refuses those once the branch is protected. Renovate pull request #792 failed with `Upload queued for processing failed: {"message":"Token required because branch is protected"}`, which `fail_ci_if_error: true` turned into a red check. The organization has since added a `CODECOV_TOKEN` actions secret, and passing it fixes that exact failure.

## What

- All three `codecov/codecov-action` steps in `.github/workflows/build.yaml` (flags `go`, `ui`, `java`) now pass `token: ${{ secrets.CODECOV_TOKEN }}`.
- A pull request from a fork keeps using the tokenless path: GitHub withholds secrets from those runs, so the token expands to an empty string there. Nothing about the fork case changes here.
- Each `token:` line carries `# zizmor: ignore[secrets-outside-env]`, matching how the existing `MAVEN_USER` and `MAVEN_PASSWORD` references in the same file are handled. The audit asks for a GitHub Environment around every secret reference, which buys nothing for a read-only upload token.
- Two comments that claimed the uploads authenticate tokenlessly were updated to match.

## How to verify

This pull request is deliberately opened from a branch in this repository rather than from a fork, so the CI run receives the secret. In run [31574217594](https://github.com/Netcracker/qubership-profiler-agent/actions/runs/31574217594) all three steps logged `Token set from input` followed by `Upload queued for processing complete`, and `codecov/patch` reported back green.

`zizmor 1.29.0 --persona=auditor` reports six `secrets-outside-env` findings on this file with the suppression comments stripped and none with them in place, so the three new ones are covered.
