### PR TITLE
ci: clear the deprecation warnings in the release workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,54 +1,97 @@
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 
+# Categories are evaluated top to bottom, and every changelog category is
+# exclusive, so each pull request lands in the first category it matches.
 categories:
   - title: "💥 Breaking Changes"
-    labels:
-      - breaking-change
-  # Component-scoped categories (PRs labeled with "component: X" + type)
+    exclusive: true
+    when:
+      label: breaking-change
+  # Component-scoped categories require both the component label and the type
+  # label, so they must come before the catch-all categories below.
   - title: "Agent - New Features"
-    labels:
-      - "component: agent"
-      - enhancement
+    exclusive: true
+    when:
+      labels:
+        - "component: agent"
+        - enhancement
+      labels-mode: all
   - title: "Agent - Bug Fixes"
-    labels:
-      - "component: agent"
-      - fix
+    exclusive: true
+    when:
+      labels:
+        - "component: agent"
+        - fix
+      labels-mode: all
   - title: "Dumps Collector - New Features"
-    labels:
-      - "component: dumps-collector"
-      - enhancement
+    exclusive: true
+    when:
+      labels:
+        - "component: dumps-collector"
+        - enhancement
+      labels-mode: all
   - title: "Dumps Collector - Bug Fixes"
-    labels:
-      - "component: dumps-collector"
-      - fix
+    exclusive: true
+    when:
+      labels:
+        - "component: dumps-collector"
+        - fix
+      labels-mode: all
   - title: "Diagtools - New Features"
-    labels:
-      - "component: diagtools"
-      - enhancement
+    exclusive: true
+    when:
+      labels:
+        - "component: diagtools"
+        - enhancement
+      labels-mode: all
   - title: "Diagtools - Bug Fixes"
-    labels:
-      - "component: diagtools"
-      - fix
+    exclusive: true
+    when:
+      labels:
+        - "component: diagtools"
+        - fix
+      labels-mode: all
   # Catch-all for PRs without component labels
   - title: "💡 New Features"
-    labels:
-      - enhancement
+    exclusive: true
+    when:
+      label: enhancement
   - title: "🐞 Bug Fixes"
-    labels:
-      - fix
+    exclusive: true
+    when:
+      label: fix
   - title: "📝 Documentation"
-    labels:
-      - documentation
+    exclusive: true
+    when:
+      label: documentation
   - title: "⚙️ Technical Debt"
-    labels:
-      - refactor
+    exclusive: true
+    when:
+      label: refactor
   - title: "🧰 Maintenance"
-    label: chore
+    exclusive: true
+    when:
+      label: chore
   - title: "⬆️ Dependencies"
     collapse-after: 8
-    labels:
-      - dependencies
+    exclusive: true
+    when:
+      label: dependencies
+
+  # Version resolution. A release without any of these labels gets a patch bump.
+  - type: version-resolver
+    semver-increment: major
+    when:
+      label: major
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      label: minor
+  - type: version-resolver
+    semver-increment: patch
+    when:
+      label: patch
 
 change-template: "- $TITLE (#$NUMBER) by @$AUTHOR"
 no-changes-template: "No significant changes"
@@ -61,20 +104,9 @@ template: |
 
   **Contributors:** $CONTRIBUTORS
 
-version-resolver:
-  major:
-    labels:
-      - major
-  minor:
-    labels:
-      - minor
-  patch:
-    labels:
-      - patch
-  default: patch
-
 # See https://github.com/release-drafter/release-drafter#autolabeler
-# This is more like a reference, since auto-labeling PRs seems to require too many privileges
+# Since v7 the autolabeler is a separate action (release-drafter/release-drafter/autolabeler),
+# so this section only takes effect once a workflow runs that action.
 autolabeler:
   - label: 'dependencies'
     files:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,9 +14,8 @@ jobs:
     permissions:
       # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
+      # release-drafter reads the merged pull requests to build the release notes
+      pull-requests: read
     name: Update Release Draft
     runs-on: ubuntu-latest
     steps:
@@ -42,7 +41,6 @@ jobs:
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         id: prepare_release
         with:
-          disable-autolabeler: false
           publish: false
           latest: ${{ github.ref_name == github.event.repository.default_branch }}
           version: ${{ steps.current_version.outputs.result }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,7 @@ jobs:
     permissions:
       # write permission is required to create a GitHub release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
+      # release-drafter reads the merged pull requests to build the release notes
       pull-requests: read
     steps:
       - name: Validate input parameters
@@ -92,7 +91,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app_token
         with:
-          app-id: ${{ vars.GH_BUMP_VERSION_APP_ID }}
+          client-id: ${{ vars.GH_BUMP_VERSION_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_BUMP_VERSION_APP_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - name: Update version in gradle.properties to ${{ steps.release_version.outputs.version }}
@@ -150,7 +149,6 @@ jobs:
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         id: publish_release
         with:
-          disable-autolabeler: true
           publish: true
           latest: ${{ github.ref_name == github.event.repository.default_branch }}
           version: ${{ steps.release_version.outputs.version }}


### PR DESCRIPTION
## Why

The last release run ([31588863553](https://github.com/Netcracker/qubership-profiler-agent/actions/runs/31588863553)) succeeded with 17 warnings in the `Publish release` job. They all come from 874541eb (`chore(deps): update major third-party github actions`): Renovate moved `release-drafter` to v7.7.0 and `create-github-app-token` to v3.2.0, but `.github/release-drafter.yml` and the two workflows still use the v6/v2 shape. The deprecated fields are scheduled for removal, so today's warnings are tomorrow's failed release.

## What

* **`disable-autolabeler` removed** from both release workflows. In release-drafter v7 the autolabeler is a separate action (`release-drafter/release-drafter/autolabeler`), and the drafter itself never labels pull requests — hence `Unexpected input(s) 'disable-autolabeler'`.
* **Categories migrated from `labels` to `when`** (13 warnings) and **`version-resolver` migrated to `type: version-resolver` categories** (3 warnings), following [the v7 migration notes](https://github.com/release-drafter/release-drafter/pull/1558). Version resolution keeps its `patch` fallback: with no matching category, v7 falls back to `patch` on its own.
* **Component-scoped categories fixed while migrating.** Each of them lists two labels (`component: agent` + `enhancement`), which release-drafter matches with OR — so "Agent - New Features" swallowed every `enhancement` pull request, and the same pull request was also rendered under the catch-all "💡 New Features". `labels-mode: all` gives the AND the config always meant, and `exclusive: true` on every changelog category keeps a pull request in the first category it matches.
* **`app-id` → `client-id`** for `actions/create-github-app-token@v3` (2 warnings).
* **`pull-requests: write` → `read`** in the draft workflow. It was only elevated for the autolabeler, which that action no longer runs.

Still warning after this change: `burrunan/gradle-cache-action` and `mlugg/setup-zig` target Node 20. `gradle-cache-action` has the Node 24 upgrade on `main` but no release after v3.0.2 yet; `setup-zig` is still on `node20` upstream, including `main`.

## Action required before merge

`vars.GH_BUMP_VERSION_APP_CLIENT_ID` (organization level, next to the existing `GH_BUMP_VERSION_APP_ID`) must hold the GitHub App's Client ID — the `Iv23li…` value on the app settings page. Without it the release job cannot mint a token and fails at "Update version in gradle.properties".

## How to verify

* `.github/release-drafter.yml` validates against release-drafter v7.7.0's `schema.json` (checked with `ajv validate --spec=draft2020`).
* The next push to `main` runs the draft workflow; its log should be free of `##[warning]Use of deprecated` and `Unexpected input(s)` lines.
* The next release run should be down to the single Node 20 warning.