### PR TITLE
fix(ci): trust the local lookup over the Renovate dashboard

### DIFF
--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -276,6 +276,17 @@ jobs:
           reasons=()
           notes=()
 
+          # The Dependency Dashboard is written by the hosted Renovate run, and
+          # its lookup failures stay on the issue until that run repeats. The
+          # lookup job resolves the same package files from this workflow and
+          # retries once, so its verdict decides whether a dashboard lookup
+          # failure is actionable here.
+          local_lookup_succeeded=false
+          if [[ "$LOOKUP_RESULT" == 'success' ]]; then
+            local_lookup_succeeded=true
+          fi
+          waived_lookup_problem_count=0
+
           issues_enabled="$(gh api "repos/$GH_REPO" --jq '.has_issues')"
           dashboard_json=''
           if [[ "$issues_enabled" == 'true' ]]; then
@@ -306,6 +317,9 @@ jobs:
               # timestamp-optional explicitly allows the affected updates to proceed.
               timestamp_optional_release_warning="⚠️ WARN: Some release(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding. See debug logs for more information"
               timestamp_optional_upgrade_warning="⚠️ WARN: Some upgrade(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding. See debug logs for more information"
+              # Renovate summarizes the same lookup failures the footer lists,
+              # so this notice adds no signal the lookup job has not checked.
+              lookup_failure_warning='⚠️ WARN: Package lookup failures'
               repository_problems_intro_pattern='^These problems occurred while renovating this repository\. \[View logs\]\(https://developer\.mend\.io/[^[:space:])]+\)\.$'
               ignored_repository_problem_count=0
               actionable_repository_problem_count=0
@@ -322,6 +336,9 @@ jobs:
                 fi
                 if [[ "$repository_problem_line" == " - $timestamp_optional_release_warning" || "$repository_problem_line" == " - $timestamp_optional_upgrade_warning" ]]; then
                   ignored_repository_problem_count=$((ignored_repository_problem_count + 1))
+                elif [[ "$local_lookup_succeeded" == true && "$repository_problem_line" == " - $lookup_failure_warning" ]]; then
+                  ignored_repository_problem_count=$((ignored_repository_problem_count + 1))
+                  waived_lookup_problem_count=$((waived_lookup_problem_count + 1))
                 else
                   actionable_repository_problem_count=$((actionable_repository_problem_count + 1))
                 fi
@@ -333,15 +350,20 @@ jobs:
 
               if [[ "$ignored_repository_problem_count" -eq 0 || "$actionable_repository_problem_count" -ne 0 ]]; then
                 reasons+=('Dependency Dashboard reports repository problems')
-              else
-                notes+=('Dependency Dashboard only reports expected timestamp-optional notices')
+              fi
+              if [[ "$ignored_repository_problem_count" -ne "$waived_lookup_problem_count" ]]; then
+                notes+=('Dependency Dashboard reports expected timestamp-optional notices')
               fi
             fi
             if grep -q '^## Errored[[:space:]]*$' <<< "$dashboard_body"; then
               reasons+=('Dependency Dashboard reports errored updates')
             fi
-            if grep -q 'Renovate failed to look up' <<< "$dashboard_body"; then
-              reasons+=('Dependency Dashboard reports lookup failures')
+            if [[ "$waived_lookup_problem_count" -ne 0 ]] || grep -q 'Renovate failed to look up' <<< "$dashboard_body"; then
+              if [[ "$local_lookup_succeeded" == true ]]; then
+                notes+=('Dependency Dashboard reports lookup failures; the local lookup job succeeded')
+              else
+                reasons+=('Dependency Dashboard reports lookup failures')
+              fi
             fi
           elif [[ "$issues_enabled" == 'true' ]]; then
             reasons+=('Renovate Dependency Dashboard was not found')
@@ -384,8 +406,13 @@ jobs:
               echo 'Healthy'
               echo
               if ((${#notes[@]} != 0)); then
+                echo '#### Notes'
+                echo
                 printf -- '- %s\n' "${notes[@]}"
+                echo
               fi
+              echo '#### Details'
+              echo
               if [[ -n "$dashboard_url" ]]; then
                 echo "- [Renovate Dependency Dashboard]($dashboard_url)"
               fi
@@ -397,6 +424,12 @@ jobs:
               trap 'rm -f "$recovery_file"' EXIT
               {
                 echo 'The Renovate health check passed. This issue is closing automatically.'
+                if ((${#notes[@]} != 0)); then
+                  echo
+                  echo '### Notes'
+                  echo
+                  printf -- '- %s\n' "${notes[@]}"
+                fi
                 echo
                 echo '### Details'
                 echo
@@ -420,6 +453,12 @@ jobs:
               echo '### Problems'
               echo
               printf -- '- %s\n' "${reasons[@]}"
+              if ((${#notes[@]} != 0)); then
+                echo
+                echo '### Notes'
+                echo
+                printf -- '- %s\n' "${notes[@]}"
+              fi
               echo
               echo '### Details'
               echo
@@ -444,6 +483,12 @@ jobs:
               echo 'Review the details below, fix the listed problems, and rerun the health check. This issue updates after repeated failures and closes automatically after a successful check.'
               echo
               echo "$opt_out_hint_issue"
+              if ((${#notes[@]} != 0)); then
+                echo
+                echo '### Notes'
+                echo
+                printf -- '- %s\n' "${notes[@]}"
+              fi
               echo
               echo '### Details'
               echo
@@ -459,12 +504,18 @@ jobs:
             echo
             echo 'Unhealthy'
             echo
+            echo '#### Problems'
+            echo
             printf -- '- %s\n' "${reasons[@]}"
             echo
             if ((${#notes[@]} != 0)); then
+              echo '#### Notes'
+              echo
               printf -- '- %s\n' "${notes[@]}"
               echo
             fi
+            echo '#### Details'
+            echo
             if [[ -n "$dashboard_url" ]]; then
               echo "- [Renovate Dependency Dashboard]($dashboard_url)"
             fi


### PR DESCRIPTION
The Renovate health check failed on the weekly schedule while nothing in this repository was broken. [Run 32719994456](https://github.com/Netcracker/qubership-profiler-agent/actions/runs/32719994456) filed [#924](https://github.com/Netcracker/qubership-profiler-agent/issues/924); the same thing happened a week earlier as [#919](https://github.com/Netcracker/qubership-profiler-agent/issues/919), which a manual re-run closed on its own.

## Why

`monitor-renovate` read two failure reasons off the [Dependency Dashboard](https://github.com/Netcracker/qubership-profiler-agent/issues/446), and both trace back to one event: a lookup failure inside the hosted Renovate run. Mend reported `no-result` for `github.com/testcontainers/testcontainers-go`, `k8s.io/api`, `k8s.io/apimachinery`, and `github.com/vlsi/jattach/v2`, which put a `⚠️ WARN: Package lookup failures` line under `## Repository Problems` and a `Renovate failed to look up` footer on the issue.

Nothing in the repository explains those four. All four are ordinary `require` entries in `backend/go.mod` and `diagtools/go.mod`, all four resolve from `proxy.golang.org`, `k8s.io/client-go` resolved in the same hosted run through the same mechanism, and the workflow's own `lookup-renovate-dependencies` job resolved every one of them in that very run.

The dashboard is a snapshot the hosted run overwrites at most once a day, so a lookup failure that lasted seconds holds the check red until the next hosted run — a week, on this schedule.

## What

`lookup-renovate-dependencies` runs `renovate --platform=local --dry-run=lookup` over the same package files and already retries once on a soft failure, so it is the stronger of the two signals. When it succeeds, the dashboard's `Package lookup failures` notice joins the timestamp-optional notices as ignorable, and the `Renovate failed to look up` footer becomes a note in the step summary rather than a reason. When it fails, is skipped, or is cancelled, both stay failures and the check behaves as before.

Every other signal is untouched: an `## Errored` section, a missing dashboard, a failed validation job, and any repository problem outside the ignorable set each still fail the check.

The trade-off is a hosted lookup failure that the local job cannot reproduce — a Mend-side credential or network fault, say. It now reports as a note in the step summary instead of an issue. That is the case this check was misreporting anyway.

## How to verify

The monitor step is shell, so it runs outside Actions. Extract the `run:` block, stub `gh`, and feed it a dashboard body:

```bash
python3 -c "import sys,yaml;sys.stdout.write(yaml.safe_load(open('.github/workflows/renovate-config-lint.yaml'))['jobs']['monitor-renovate']['steps'][0]['run'])" > monitor.sh
```

Against the body of #446 as it stood during the failing run:

| Dashboard | `LOOKUP_RESULT` | Before | After |
| --- | --- | --- | --- |
| #446 as captured | `success` | fails, both reasons | passes, both as notes |
| #446 as captured | `failure` | fails | fails |
| #446 plus an unrecognized WARN | `success` | fails | fails |
| timestamp-optional notices only | `success` | passes | passes |
| `## Errored` section | `success` | fails | fails |
| no dashboard, issues enabled | `success` | fails | fails |

The first row is run 32719994456 reproduced, and the third is the guard against over-filtering.

## Reporting

The check now says what it waived, in every artifact it writes. A cross-review of the first commit found four gaps, all in what the step reports rather than what it decides.

The two waiver kinds — the chronic timestamp-optional notices and the newly waived lookup notice — are counted separately and each gets its own note, decided independently, so an actionable bullet in the same section no longer swallows the timestamp waiver. The waived `Package lookup failures` notice reaches the same branch as the `Renovate failed to look up` footer, which covers a dashboard carrying one without the other.

Every durable artifact carries the notes under `### Notes`, not only the step summary: a health issue could otherwise close as `passed` while the dashboard it links still lists the failures. Both summaries take the `### Problems` / `### Notes` / `### Details` shape the issue bodies use, with `####` subsections to match the lookup job's summary. A heading is what closes a Markdown list — a blank line only makes it loose — so without one the notes and the links render as a single list.

The lookup note no longer claims the local run "did not reproduce" the dashboard's failures. It can reproduce them: the lookup job also passes when its first attempt fails and its retry recovers, and that run's own summary prints `#### Initial lookup failures`. The note states the two facts the step measured and quantifies over no dependency set.

## Scope

`.github/workflows/renovate-config-lint.yaml` came from `Netcracker/.github/workflow-templates/renovate-config-lint.yaml`, and 24 other Netcracker repositories carry a copy identical to this file apart from the cron slot and the Renovate image digest. The templates are copied by hand, so nothing propagates this fix on its own. The same patch applies cleanly to the template.
