### PR TITLE
fix(rabbitmq): support ByteBuffer in basicPublish instrumentation

### DIFF
--- a/plugins/rabbitmq/src/injector/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/plugins/rabbitmq/src/injector/java/com/rabbitmq/client/impl/ChannelN.java
@@ -2,11 +2,26 @@ package com.rabbitmq.client.impl;
 
 import com.netcracker.profiler.agent.Profiler;
 
+import java.nio.ByteBuffer;
+
 public class ChannelN {
     public void basicPublish$profiler(String exchange, String routingKey, byte[] body, Throwable throwable) {
         Profiler.event(exchange, "rabbitmq.exchange");
         Profiler.event(routingKey, "rabbitmq.routingKey");
-        int length = Math.min(body.length, 100);
-        Profiler.event(new String(body, 0, length), "rabbitmq.message");
+        if (body != null) {
+            int length = Math.min(body.length, 100);
+            Profiler.event(new String(body, 0, length), "rabbitmq.message");
+        }
+    }
+
+    public void basicPublish$profiler(String exchange, String routingKey, ByteBuffer body, Throwable throwable) {
+        Profiler.event(exchange, "rabbitmq.exchange");
+        Profiler.event(routingKey, "rabbitmq.routingKey");
+        if (body != null) {
+            ByteBuffer duplicate = body.duplicate();
+            byte[] bytes = new byte[Math.min(duplicate.remaining(), 100)];
+            duplicate.get(bytes);
+            Profiler.event(new String(bytes), "rabbitmq.message");
+        }
     }
 }


### PR DESCRIPTION
# Pull Request

## Describe Your Changes
Fixes a NoSuchMethodError when RabbitMQ ChannelN.basicPublish() is instrumented with a ByteBuffer body.

Adds the missing basicPublish$profiler(String, String, ByteBuffer, Throwable) overload while keeping the existing byte[] overload for compatibility.

The ByteBuffer implementation uses duplicate() to preserve the original buffer position and captures up to 100 bytes of the message body.

Checklist

The following checks are **mandatory**:

* [ ] My change adheres [Qubership contributing guidelines](../CONTRIBUTING.md).
