### PR TITLE
chore: switch PR assignment to the reviewer lottery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @asatt @IldarMinaev @vlsi
+* @asatt @denifilatoff @vlsi

--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -1,0 +1,11 @@
+---
+
+groups:
+  - name: rotating
+    reviewers: 1
+    usernames:
+      - Beauline
+      - NikolaiKuziaevQubership
+      - dmitriikazanin
+      - bagwan-shoaib
+      - al-matushkin

--- a/.github/workflows/pr-reviewer-lottery.yaml
+++ b/.github/workflows/pr-reviewer-lottery.yaml
@@ -1,0 +1,46 @@
+---
+
+# Assigns the PR author as the assignee and draws one random reviewer from .github/reviewer-lottery.yml.
+# Code owners are requested separately by GitHub through .github/CODEOWNERS.
+
+name: Reviewer Lottery
+run-name: "PR: Assigning reviewers for PR #${{ github.event.pull_request.number }}"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  reviewer-lottery:
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Assign the PR author
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        # Outside contributors cannot be assigned, so a failure here must not block the lottery.
+        run: |
+          gh pr edit "${PR_NUMBER}" --add-assignee "${PR_AUTHOR}" ||
+            echo "::notice::Cannot assign ${PR_AUTHOR}: the author is not a collaborator of this repository."
+
+      - name: Draw a reviewer
+        uses: uesteibar/reviewer-lottery@3c9b63ea22c4d74336ea95ca4aeeab856ca2c037 # v4.0.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Why

`@IldarMinaev` no longer reviews for this repository, so `.github/CODEOWNERS` requests review from an owner who cannot respond. Review requests here came from `.github/CODEOWNERS` alone, which sends every PR to the same owners and gives no rotation.

# What

- Replace `@IldarMinaev` with `@denifilatoff` in `.github/CODEOWNERS`.
- Add the `Reviewer Lottery` workflow and `.github/reviewer-lottery.yml`. On a new, reopened, or ready-for-review PR it assigns the author and draws one reviewer at random from the rotating group.

GitHub still requests code owners separately through `.github/CODEOWNERS`. The workflow and the roster are copied from [qubership-monitoring-operator](https://github.com/Netcracker/qubership-monitoring-operator/blob/main/.github/workflows/pr-reviewer-lottery.yaml), which has been running this setup since #517.

# How to verify

Open a PR against `main` and check the `Reviewer Lottery` run in the Actions tab. Expect the author as assignee, one review request from the rotating group, and the usual code-owner request from GitHub. Bot PRs skip the job. An author who is not a collaborator produces a notice in the log instead of a failed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
