### PR TITLE
fix(rabbitmq): record a binary message body as hex, and decode text by its headers

### DIFF
--- a/boot/src/main/java/com/netcracker/profiler/agent/MessageBody.java
+++ b/boot/src/main/java/com/netcracker/profiler/agent/MessageBody.java
@@ -1,0 +1,214 @@
+package com.netcracker.profiler.agent;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Renders the head of a message body as a parameter value: text as the decoded characters, any
+ * other body as {@code hex[<length>]: <hex digits>}, where the length counts the whole body.
+ *
+ * <p>A hex value carries the content type and the content encoding after the length, as in
+ * {@code hex[1834, type=application/json, encoding=gzip:UTF-8]: 1f8b0800}. Each is left out when it
+ * is absent, and the content encoding also when it is {@code identity}.</p>
+ *
+ * <p>The message headers decide first. A content encoding other than {@code identity} that names
+ * no supported charset, such as {@code gzip} or {@code gzip:UTF-8}, marks a compressed body, which
+ * is rendered as hex. A textual content type marks text, and bytes the charset cannot decode become
+ * U+FFFD. The textual types are {@code text/*} and the subtypes {@code json}, {@code xml},
+ * {@code yaml}, {@code x-yaml}, {@code javascript}, and {@code x-www-form-urlencoded}, alone or as a
+ * {@code +} suffix. Any other body, including one sent as {@code application/octet-stream} or with
+ * no content type, is text only when it decodes without error and contains no ISO control
+ * character other than tab, line feed, and carriage return. Protobuf fails that check wherever it
+ * holds a tag of fields 1 to 3 or a length below 32, since those bytes are control characters.</p>
+ *
+ * <p>The charset is a supported {@code charset} parameter of the content type, else a content
+ * encoding that names a supported charset, else UTF-8. When the head is shorter than the body, a
+ * multibyte character cut at its end is dropped rather than treated as malformed.</p>
+ */
+public final class MessageBody {
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    private static final int MAX_CACHED_NAMES = 64;
+
+    /** Charset names mapped to their {@link Charset}, or to {@link #UNSUPPORTED}. */
+    private static final ConcurrentHashMap<String, Object> CHARSETS = new ConcurrentHashMap<>();
+
+    private static final Object UNSUPPORTED = new Object();
+
+    private MessageBody() {
+    }
+
+    /**
+     * Renders at most {@code limit} leading bytes of {@code body}.
+     *
+     * @param contentType     the content type header, or {@code null}
+     * @param contentEncoding the content encoding header, or {@code null}
+     */
+    public static String describe(byte[] body, int limit, String contentType, String contentEncoding) {
+        ByteBuffer head = ByteBuffer.wrap(body, 0, Math.min(body.length, limit));
+        return render(head, body.length, contentType, contentEncoding);
+    }
+
+    /**
+     * Renders at most {@code limit} bytes of {@code body}, starting at its position, and leaves
+     * the position and the limit of {@code body} unchanged.
+     *
+     * @param contentType     the content type header, or {@code null}
+     * @param contentEncoding the content encoding header, or {@code null}
+     */
+    public static String describe(ByteBuffer body, int limit, String contentType, String contentEncoding) {
+        ByteBuffer head = body.duplicate();
+        int length = head.remaining();
+        if (length > limit) {
+            head.limit(head.position() + limit);
+        }
+        return render(head, length, contentType, contentEncoding);
+    }
+
+    private static String render(ByteBuffer head, int length, String contentType, String contentEncoding) {
+        String encoding = contentEncoding == null ? "" : contentEncoding.trim();
+        Charset encodingCharset = encoding.isEmpty() ? null : lookup(encoding);
+        if ("identity".equalsIgnoreCase(encoding)) {
+            encoding = "";
+        }
+        boolean compressed = !encoding.isEmpty() && encodingCharset == null;
+        if (!compressed) {
+            Charset charset = lookup(charsetParameter(contentType));
+            if (charset == null) {
+                charset = encodingCharset != null ? encodingCharset : StandardCharsets.UTF_8;
+            }
+            boolean declaredText = isTextType(contentType);
+            boolean truncated = head.remaining() < length;
+            String text = decode(head.duplicate(), charset,
+                    declaredText ? CodingErrorAction.REPLACE : CodingErrorAction.REPORT, truncated);
+            if (text != null && (declaredText || !containsControlCharacter(text))) {
+                return text;
+            }
+        }
+        return hex(head, length, contentType == null ? "" : contentType.trim(), encoding);
+    }
+
+    /** Returns the decoded characters, or {@code null} when {@code onError} reports an error. */
+    private static String decode(ByteBuffer bytes, Charset charset, CodingErrorAction onError, boolean truncated) {
+        CharsetDecoder decoder = charset.newDecoder()
+                .onMalformedInput(onError)
+                .onUnmappableCharacter(onError);
+        CharBuffer chars = CharBuffer.allocate((int) (bytes.remaining() * (double) decoder.maxCharsPerByte()) + 1);
+        // With endOfInput false, the decoder leaves an incomplete trailing sequence in the buffer
+        CoderResult result = decoder.decode(bytes, chars, !truncated);
+        if (!result.isUnderflow()) {
+            return null;
+        }
+        if (!truncated && !decoder.flush(chars).isUnderflow()) {
+            return null;
+        }
+        chars.flip();
+        return chars.toString();
+    }
+
+    private static boolean containsControlCharacter(String text) {
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (Character.isISOControl(c) && c != '\t' && c != '\n' && c != '\r') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String hex(ByteBuffer head, int length, String contentType, String encoding) {
+        StringBuilder sb = new StringBuilder(32 + contentType.length() + encoding.length() + 2 * head.remaining());
+        sb.append("hex[").append(length);
+        if (!contentType.isEmpty()) {
+            sb.append(", type=").append(contentType);
+        }
+        if (!encoding.isEmpty()) {
+            sb.append(", encoding=").append(encoding);
+        }
+        sb.append("]: ");
+        for (int i = head.position(); i < head.limit(); i++) {
+            int b = head.get(i) & 0xff;
+            sb.append(HEX[b >>> 4]).append(HEX[b & 0xf]);
+        }
+        return sb.toString();
+    }
+
+    private static boolean isTextType(String contentType) {
+        if (contentType == null) {
+            return false;
+        }
+        int semicolon = contentType.indexOf(';');
+        String mimeType = (semicolon < 0 ? contentType : contentType.substring(0, semicolon))
+                .trim().toLowerCase(Locale.ROOT);
+        if (mimeType.startsWith("text/")) {
+            return true;
+        }
+        int slash = mimeType.indexOf('/');
+        if (slash < 0) {
+            return false;
+        }
+        String subtype = mimeType.substring(Math.max(slash, mimeType.lastIndexOf('+')) + 1);
+        switch (subtype) {
+            case "json":
+            case "xml":
+            case "yaml":
+            case "x-yaml":
+            case "javascript":
+            case "x-www-form-urlencoded":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static String charsetParameter(String contentType) {
+        if (contentType == null) {
+            return null;
+        }
+        String[] parts = contentType.split(";");
+        for (int i = 1; i < parts.length; i++) {
+            String parameter = parts[i].trim();
+            if (parameter.regionMatches(true, 0, "charset=", 0, "charset=".length())) {
+                String value = parameter.substring("charset=".length()).trim();
+                if (value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
+                    value = value.substring(1, value.length() - 1);
+                }
+                return value;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the charset, or {@code null} for a name that is illegal or unsupported.
+     *
+     * <p>Results are cached, failures included, because {@link Charset#forName(String)} scans the
+     * charset providers on every miss, which takes about 70 µs, and a compressed message names an
+     * unsupported charset on every publish. The cache stops growing at {@value #MAX_CACHED_NAMES}
+     * names, since the names come from message headers.</p>
+     */
+    private static Charset lookup(String name) {
+        if (name == null || name.isEmpty()) {
+            return null;
+        }
+        Object cached = CHARSETS.get(name);
+        if (cached == null) {
+            try {
+                cached = Charset.forName(name);
+            } catch (IllegalArgumentException e) {
+                cached = UNSUPPORTED;
+            }
+            if (CHARSETS.size() < MAX_CACHED_NAMES) {
+                CHARSETS.putIfAbsent(name, cached);
+            }
+        }
+        return cached instanceof Charset ? (Charset) cached : null;
+    }
+}

--- a/boot/src/test/kotlin/com/netcracker/profiler/agent/MessageBodyTest.kt
+++ b/boot/src/test/kotlin/com/netcracker/profiler/agent/MessageBodyTest.kt
@@ -1,0 +1,204 @@
+package com.netcracker.profiler.agent
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.nio.ByteBuffer
+
+/**
+ * A body whose content encoding marks it compressed is rendered as
+ * `hex[<whole length>, type=<content type>, encoding=<content encoding>]: <hex of the head>`. Any
+ * other body is text when its content type declares text, or when its head decodes cleanly and
+ * holds no control character other than tab, line feed, and carriage return; otherwise it is
+ * rendered as hex too. A hex value leaves out a header that is absent, and the `identity` content
+ * encoding.
+ */
+class MessageBodyTest {
+    private fun bytes(vararg values: Int) = ByteArray(values.size) { values[it].toByte() }
+
+    /** "Привет" in UTF-8: six two-byte characters. */
+    private val privetUtf8 = bytes(0xd0, 0x9f, 0xd1, 0x80, 0xd0, 0xb8, 0xd0, 0xb2, 0xd0, 0xb5, 0xd1, 0x82)
+
+    /** "Привет" in windows-1251, which is malformed as UTF-8. */
+    private val privetCp1251 = bytes(0xcf, 0xf0, 0xe8, 0xe2, 0xe5, 0xf2)
+
+    @Test
+    fun `a UTF-8 body with no headers is rendered as text`() {
+        assertEquals("Привет", MessageBody.describe(privetUtf8, 100, null, null))
+    }
+
+    @Test
+    fun `tab, line feed, and carriage return keep a body text`() {
+        assertEquals("a\tb\r\nc", MessageBody.describe("a\tb\r\nc".toByteArray(), 100, null, null))
+    }
+
+    @Test
+    fun `an empty body is rendered as empty text`() {
+        assertEquals("", MessageBody.describe(ByteArray(0), 100, null, null))
+    }
+
+    @Test
+    fun `a head that ends between two characters is rendered whole`() {
+        assertEquals("Привет", MessageBody.describe(privetUtf8, 12, null, null))
+    }
+
+    @Test
+    fun `a character cut by the limit is dropped`() {
+        assertEquals("Приве", MessageBody.describe(privetUtf8, 11, null, null))
+    }
+
+    @Test
+    fun `a character cut by the limit is dropped from a declared text body`() {
+        assertEquals("Приве", MessageBody.describe(privetUtf8, 11, "text/plain", "UTF-8"))
+    }
+
+    @Test
+    fun `DEL marks a body binary`() {
+        assertEquals("hex[3]: 617f62", MessageBody.describe(bytes(0x61, 0x7f, 0x62), 100, null, null))
+    }
+
+    @Test
+    fun `a C1 control character marks a body binary`() {
+        // U+0085, next line, in UTF-8
+        assertEquals("hex[2]: c285", MessageBody.describe(bytes(0xc2, 0x85), 100, null, null))
+    }
+
+    @Test
+    fun `a complete body that ends inside a character is rendered as hex`() {
+        assertEquals("hex[3]: d09fd1", MessageBody.describe(bytes(0xd0, 0x9f, 0xd1), 100, null, null))
+    }
+
+    @Test
+    fun `a Java serialization stream is rendered as hex`() {
+        assertEquals(
+            "hex[4, type=application/x-java-serialized-object]: aced0005",
+            MessageBody.describe(bytes(0xac, 0xed, 0x00, 0x05), 100, "application/x-java-serialized-object", null)
+        )
+    }
+
+    @Test
+    fun `protobuf that is valid UTF-8 is rendered as hex for its control bytes`() {
+        // Field 2, length 4, "test"
+        assertEquals(
+            "hex[6]: 120474657374",
+            MessageBody.describe(bytes(0x12, 0x04, 0x74, 0x65, 0x73, 0x74), 100, null, null)
+        )
+    }
+
+    @Test
+    fun `hex counts the whole body and shows only the head`() {
+        assertEquals(
+            "hex[10]: 1f8b0800",
+            MessageBody.describe(bytes(0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03), 4, null, null)
+        )
+    }
+
+    @Test
+    fun `a compressing content encoding renders a printable body as hex`() {
+        assertEquals(
+            "hex[2, type=application/json, encoding=gzip:UTF-8]: 7b7d",
+            MessageBody.describe("{}".toByteArray(), 100, "application/json", "gzip:UTF-8")
+        )
+    }
+
+    @Test
+    fun `an illegal charset name in the content encoding renders the body as hex`() {
+        assertEquals("hex[2, encoding=not a charset!]: 7b7d", MessageBody.describe("{}".toByteArray(), 100, null, "not a charset!"))
+    }
+
+    @Test
+    fun `the identity content encoding leaves a body text`() {
+        assertEquals("{}", MessageBody.describe("{}".toByteArray(), 100, null, "identity"))
+    }
+
+    @Test
+    fun `hex omits the identity content encoding`() {
+        assertEquals("hex[2]: 1f8b", MessageBody.describe(bytes(0x1f, 0x8b), 100, null, "identity"))
+    }
+
+    @Test
+    fun `hex carries a charset content encoding the bytes do not decode in`() {
+        assertEquals("hex[3, encoding=UTF-8]: d09fd1", MessageBody.describe(bytes(0xd0, 0x9f, 0xd1), 100, null, "UTF-8"))
+    }
+
+    @Test
+    fun `a charset in the content encoding decodes the body`() {
+        assertEquals("Привет", MessageBody.describe(privetCp1251, 100, null, "windows-1251"))
+    }
+
+    @Test
+    fun `the charset parameter of the content type wins over the content encoding`() {
+        assertEquals(
+            "Привет",
+            MessageBody.describe(privetCp1251, 100, "text/plain; charset=\"windows-1251\"", "UTF-8")
+        )
+    }
+
+    @Test
+    fun `an unquoted charset parameter decodes the body`() {
+        assertEquals("Привет", MessageBody.describe(privetCp1251, 100, "text/plain;charset=windows-1251", null))
+    }
+
+    @Test
+    fun `an unsupported charset parameter falls back to UTF-8`() {
+        assertEquals("Привет", MessageBody.describe(privetUtf8, 100, "text/plain; charset=x-no-such-charset", null))
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "text/csv",
+            "application/json",
+            "application/xml",
+            "application/yaml",
+            "application/x-yaml",
+            "application/javascript",
+            "application/x-www-form-urlencoded",
+            "application/vnd.api+json",
+            "application/atom+xml",
+            "application/vnd.oai.openapi+yaml",
+        ]
+    )
+    fun `a declared text type keeps a control character`(contentType: String) {
+        assertEquals("\u001b[31mred", MessageBody.describe("\u001b[31mred".toByteArray(), 100, contentType, null))
+    }
+
+    @Test
+    fun `an octet-stream body is rendered as text when it decodes cleanly`() {
+        assertEquals(
+            "{\"id\":1}",
+            MessageBody.describe("{\"id\":1}".toByteArray(), 100, "application/octet-stream", null)
+        )
+    }
+
+    @Test
+    fun `a control character renders a body of another type as hex`() {
+        assertEquals(
+            "hex[8, type=application/x-protobuf]: 1b5b33316d726564",
+            MessageBody.describe("\u001b[31mred".toByteArray(), 100, "application/x-protobuf", null)
+        )
+    }
+
+    @Test
+    fun `a declared text type replaces a malformed byte`() {
+        assertEquals("{\uFFFD}", MessageBody.describe(bytes(0x7b, 0xff, 0x7d), 100, "Text/Plain", null))
+    }
+
+    @Test
+    fun `a ByteBuffer is read from its position and left unmoved`() {
+        val buffer = ByteBuffer.wrap(bytes(0x00, 0x01, 0xac, 0xed, 0x00, 0x05))
+        buffer.position(2)
+
+        val described = MessageBody.describe(buffer, 3, null, null)
+
+        assertEquals("hex[4]: aced00", described)
+        assertEquals(2, buffer.position(), "position after describe")
+        assertEquals(6, buffer.limit(), "limit after describe")
+    }
+
+    @Test
+    fun `a ByteBuffer shorter than the limit is read whole`() {
+        assertEquals("{}", MessageBody.describe(ByteBuffer.wrap("{}".toByteArray()), 100, null, null))
+    }
+}

--- a/plugins/rabbitmq/src/injector/java/com/rabbitmq/client/AMQP.java
+++ b/plugins/rabbitmq/src/injector/java/com/rabbitmq/client/AMQP.java
@@ -1,0 +1,8 @@
+package com.rabbitmq.client;
+
+public interface AMQP {
+    class BasicProperties {
+        public native String getContentType();
+        public native String getContentEncoding();
+    }
+}

--- a/plugins/rabbitmq/src/injector/java/com/rabbitmq/client/impl/ChannelN.java
+++ b/plugins/rabbitmq/src/injector/java/com/rabbitmq/client/impl/ChannelN.java
@@ -1,17 +1,30 @@
 package com.rabbitmq.client.impl;
 
+import com.netcracker.profiler.agent.MessageBody;
 import com.netcracker.profiler.agent.Profiler;
+
+import com.rabbitmq.client.AMQP;
 
 import java.nio.ByteBuffer;
 
 public class ChannelN {
-    /** Records the publish, and the first 100 bytes of the body where the caller supplied one. */
-    public void basicPublish$profiler(String exchange, String routingKey, byte[] body, Throwable throwable) {
+    /**
+     * Records the publish, and the first 100 bytes of the body where the caller supplied one, as
+     * {@link MessageBody#describe(byte[], int, String, String)} renders them.
+     *
+     * <p>The properties are null where the caller passed none: the client substitutes its own
+     * defaults inside the method, and the hook receives the argument as the caller passed it.</p>
+     */
+    public void basicPublish$profiler(String exchange, String routingKey, AMQP.BasicProperties props, byte[] body,
+            Throwable throwable) {
         Profiler.event(exchange, "rabbitmq.exchange");
         Profiler.event(routingKey, "rabbitmq.routingKey");
         if (body != null) {
-            int length = Math.min(body.length, 100);
-            Profiler.event(new String(body, 0, length), "rabbitmq.message");
+            Profiler.event(
+                    MessageBody.describe(body, 100,
+                            props == null ? null : props.getContentType(),
+                            props == null ? null : props.getContentEncoding()),
+                    "rabbitmq.message");
         }
     }
 
@@ -22,16 +35,18 @@ public class ChannelN {
      * <p>The body is null where the caller published through the {@code byte[]} overload with a null
      * array: from 5.31.0 that overload wraps a non-null array and passes null on unchanged, so an
      * unguarded read here would throw {@code NullPointerException} inside a publish the client
-     * accepts.</p>
+     * accepts. The properties are null where the caller passed none.</p>
      */
-    public void basicPublish$profiler(String exchange, String routingKey, ByteBuffer body, Throwable throwable) {
+    public void basicPublish$profiler(String exchange, String routingKey, AMQP.BasicProperties props, ByteBuffer body,
+            Throwable throwable) {
         Profiler.event(exchange, "rabbitmq.exchange");
         Profiler.event(routingKey, "rabbitmq.routingKey");
         if (body != null) {
-            ByteBuffer duplicate = body.duplicate();
-            byte[] bytes = new byte[Math.min(duplicate.remaining(), 100)];
-            duplicate.get(bytes);
-            Profiler.event(new String(bytes), "rabbitmq.message");
+            Profiler.event(
+                    MessageBody.describe(body, 100,
+                            props == null ? null : props.getContentType(),
+                            props == null ? null : props.getContentEncoding()),
+                    "rabbitmq.message");
         }
     }
 }

--- a/plugins/rabbitmq/src/main/resources/config/minimal/50main/rabbitmq.xml
+++ b/plugins/rabbitmq/src/main/resources/config/minimal/50main/rabbitmq.xml
@@ -11,12 +11,12 @@
             <class>com.rabbitmq.client.impl.ChannelN</class>
             <if-class-does-not-declare>basicPublish(java.lang.String, java.lang.String, boolean, boolean, com.rabbitmq.client.AMQP$BasicProperties, java.nio.ByteBuffer, com.rabbitmq.client.WriteListener)</if-class-does-not-declare>
             <method>basicPublish(java.lang.String, java.lang.String, boolean, boolean, com.rabbitmq.client.AMQP$BasicProperties, byte[])</method>
-            <execute-after type="com/rabbitmq/client/impl/ChannelN" exception="true">basicPublish$profiler(p1, p2, p6, throwable)</execute-after>
+            <execute-after type="com/rabbitmq/client/impl/ChannelN" exception="true">basicPublish$profiler(p1, p2, p5, p6, throwable)</execute-after>
         </rule>
         <rule>
             <class>com.rabbitmq.client.impl.ChannelN</class>
             <method>basicPublish(java.lang.String, java.lang.String, boolean, boolean, com.rabbitmq.client.AMQP$BasicProperties, java.nio.ByteBuffer, com.rabbitmq.client.WriteListener)</method>
-            <execute-after type="com/rabbitmq/client/impl/ChannelN" exception="true">basicPublish$profiler(p1, p2, p6, throwable)</execute-after>
+            <execute-after type="com/rabbitmq/client/impl/ChannelN" exception="true">basicPublish$profiler(p1, p2, p5, p6, throwable)</execute-after>
         </rule>
         <rule>
             <class>org.springframework.amqp.rabbit.listener.adapter.MessagingMessageListenerAdapter</class>


### PR DESCRIPTION
## Why

The RabbitMQ publish hook recorded the first 100 bytes of the body in `rabbitmq.message` with `new String(bytes)`, which decodes with the platform default charset. A gzip, Java serialization, or protobuf body was recorded as unreadable characters, UTF-8 text was garbled on a JVM whose default charset is not UTF-8, and a multibyte character cut at byte 100 ended the value with U+FFFD.

## What

The hook now also receives the fifth `basicPublish` argument, `AMQP.BasicProperties`, and hands `contentType` and `contentEncoding` to a new `MessageBody` class in `boot`. The properties are null when the caller passed none: amqp-client substitutes `MINIMAL_BASIC` inside the method, and the hook receives the argument as saved at method entry.

- A `contentEncoding` other than `identity` that names no supported charset marks the body binary. spring-amqp puts either a charset there (`UTF-8`, from its message converters) or a compression (`gzip`, `gzip:UTF-8`, `deflate`, `zip`, from `AbstractCompressingPostProcessor`).
- A textual `contentType` marks the body text: `text/*` and the subtypes `json`, `xml`, `yaml`, `x-yaml`, `javascript`, and `x-www-form-urlencoded`, alone or as a `+` suffix. The charset is the `charset=` parameter, else a `contentEncoding` that names a charset, else UTF-8.
- Otherwise the head is text when it decodes without error and holds no control character other than tab, line feed, and carriage return. The incomplete character that the 100-byte cut leaves at the end is dropped rather than counted as malformed. `application/octet-stream` goes through this check instead of being taken as binary, because spring-amqp sends every `byte[]` payload with that type.

**The format of `rabbitmq.message` changes for binary bodies.** Such a body is now recorded as `hex[<length of the whole body>, type=<contentType>, encoding=<contentEncoding>]: <hex of the first 100 bytes>`, for example `hex[1834, type=application/json, encoding=gzip:UTF-8]: 1f8b0800…`. A header that is absent is left out, and so is the `identity` content encoding, so a publish from bare amqp-client gives `hex[4]: aced0005`. The two headers name what the bytes hold, such as `application/x-protobuf` or `gzip`, and a charset in the content encoding, as in `hex[3, encoding=UTF-8]: d09fd1`, shows that the header promised text the bytes did not decode as. The labels keep the two apart when only one is present. A text body keeps its old form, without a prefix. Hex was chosen over Base64 because signatures such as `1f8b` (gzip) and `aced` (Java serialization) stay readable in it.

A table of file signatures was left out: gzip, zstd, zip, Avro containers, and Java serialization streams all fail the UTF-8 check or the control-character check within their first bytes.

`MessageBody` caches charset lookups, failures included, up to 64 names. `Charset.forName` scans the charset providers on every miss, so without the cache a publish with `gzip:UTF-8` spent 69 µs in it; with the cache the call takes 0.26 µs. The figures are the mean of 20000 calls on a 1000-byte body after warm-up, JDK 17 on a laptop.

`MessageBody` lives in `boot` because the hook runs in the application's class loader and reaches the profiler only through bootstrap classes. There it is also testable as a plain class.

## How to verify

`MessageBodyTest` (new) covers text with and without headers; a cut at a character boundary and inside a multibyte character, with and without a declared text type; gzip, Java serialization, and protobuf bytes; a compressing content encoding over a printable body, `identity`, and an illegal charset name, with the content type and the content encoding shown in the hex value, and `identity` left out; the charset taken from a quoted, an unquoted, and an unsupported `charset=` parameter and from the content encoding; each textual subtype; DEL and a C1 control character; and a `ByteBuffer` read from a non-zero position, and one shorter than the limit. A hand-made mutant of each rule fails at least one case.

`./gradlew :plugins:rabbitmq:test` runs the plugin-testkit checks against amqp-client 5.30.0 and 5.31.0 and spring-rabbit 2.4.17 and 3.2.6. They confirm that the new `basicPublish$profiler(p1, p2, p5, p6, throwable)` call sites resolve on both `basicPublish` overloads.

## Scope

The null-`props` branch of the hook is not run by any test: running it needs amqp-client's real `ChannelN` with a connection, and the testkit checks bytecode only. The consumer hook records no body and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
