### PR TITLE
build: publish profiler.war to Maven Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     nmcpAggregation(projects.parsers)
     nmcpAggregation(projects.pluginGenerator)
     nmcpAggregation(projects.pluginRuntime)
+    nmcpAggregation(projects.profiler)
     nmcpAggregation(projects.protoDefinition)
     nmcpAggregation(projects.runtime)
     nmcpAggregation(projects.warLib)

--- a/profiler/build.gradle.kts
+++ b/profiler/build.gradle.kts
@@ -43,6 +43,10 @@ val warElements = configurations.consumable("warElements") {
     outgoing.artifact(tasks.war)
 }
 
+// Publish profiler.war to Maven repository so users can consume it
+(components["java"] as AdhocComponentWithVariants).addVariantsFromConfiguration(warElements.get()) {
+}
+
 dependencies {
     implementation(projects.warLib) {
         attributes {


### PR DESCRIPTION
## Describe Your Changes

Releases did not publish `profiler.war` to Maven Central. The `profiler` module exposed the war only through the `warElements` configuration used by `it-e2e`, and the module was missing from the `nmcpAggregation` list, so the release upload skipped the module entirely.

The change adds `warElements` as a variant of the `java` component, the way `installer` publishes its zip, and adds `profiler` to `nmcpAggregation`. The war is published as `org.qubership.profiler:qubership-profiler-profiler:<version>` with extension `war`, so Maven users consume it with `<type>war</type>`; Gradle users can select the `warElements` variant (`libraryelements=war`).

The module's jar, sources, and javadoc now go to Central as well. The jar is nearly empty (about 4 KB), since the code lives in `war-lib`. The POM gets `<packaging>pom</packaging>`, the same as `installer`, because the jar and the war share no classifier.

Verification: `./gradlew nmcpZipAggregation nmcpCheckAggregationFiles -Prelease=true -PuseInMemoryPgpKeys=false` succeeds locally, and `build/nmcp/zip/aggregation.zip` contains `qubership-profiler-profiler-4.0.6.war` with its `.asc`, `.md5`, `.sha1`, and `.sha512` files.

## Checklist

The following checks are **mandatory**:

* [x] My change adheres [Qubership contributing guidelines](../CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
