### PR TITLE
test(backend): wait for the whole dictionary before sealing in the integration tests

### DIFF
--- a/backend/libs/tests/integration/coldread_test.go
+++ b/backend/libs/tests/integration/coldread_test.go
@@ -323,11 +323,9 @@ func TestColdReadPath(t *testing.T) {
 	sendStream(t, acA, model.StreamCalls, 0, wire.CallsStreamRecords(baseMs, callsA))
 	waitForIndexedCalls(t, store, bucket1, keyA, 4)
 	// The dictionary decodes on its own pipeline; the seal below re-derives
-	// error_flag against it and resolves the blob methods, so it must have
-	// landed before the pass runs.
-	require.Eventually(t, func() bool {
-		return prA.Dictionary()[sealDictCallRed] == "call.red"
-	}, 5*time.Second, 10*time.Millisecond, "dictionary must decode before the seal")
+	// error_flag against it and resolves the blob methods and param names, so
+	// every word must have landed before the pass runs.
+	waitForDictionary(t, prA, sealDictWords)
 
 	resA1, err := store.Seal(ctx, keyA, bucket1)
 	require.NoError(t, err)
@@ -762,6 +760,21 @@ func waitForIndexedCalls(t *testing.T, store *hotstore.Store, bucket int64, key 
 		}
 		return n == want
 	}, 5*time.Second, 10*time.Millisecond, "bucket must index %d calls of %s", want, key)
+}
+
+// waitForDictionary waits until the pod-restart's dictionary holds every word
+// of words, at the id equal to its index. The ingest pipeline appends one word
+// per lock acquisition, so a wait on one word alone can pass while later words
+// are still in flight; a seal taken then renders their ids as "#<id>".
+func waitForDictionary(t *testing.T, pr *hotstore.PodRestart, words []string) {
+	t.Helper()
+	want := make(map[int]string, len(words))
+	for id, word := range words {
+		want[id] = word
+	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, want, pr.Dictionary())
+	}, 5*time.Second, 10*time.Millisecond, "dictionary of %s must hold every fixture word", pr.Key)
 }
 
 // assertTraceBlobNotRead proves the column projection: no recorded read of

--- a/backend/libs/tests/integration/fanout_test.go
+++ b/backend/libs/tests/integration/fanout_test.go
@@ -154,9 +154,7 @@ func TestHotColdFanout(t *testing.T) {
 		}
 	}
 	sendStream(t, acH, model.StreamDictionary, 0, wire.DictionaryStream(sealDictWords))
-	require.Eventually(t, func() bool {
-		return prH.Dictionary()[sealDictCallRed] == "call.red"
-	}, 5*time.Second, 10*time.Millisecond, "dictionary must decode before the seal")
+	waitForDictionary(t, prH, sealDictWords)
 
 	resHOld, err := storeA.Seal(ctx, keyH, bucketOld)
 	require.NoError(t, err)

--- a/backend/libs/tests/integration/janitor_test.go
+++ b/backend/libs/tests/integration/janitor_test.go
@@ -63,9 +63,7 @@ func TestJanitorHotDropZeroGap(t *testing.T) {
 	pr, ok := store.PodRestart(key)
 	require.True(t, ok)
 	sendStream(t, ac, model.StreamDictionary, 0, wire.DictionaryStream(sealDictWords))
-	require.Eventually(t, func() bool {
-		return pr.Dictionary()[sealDictCallRed] == "call.red"
-	}, 5*time.Second, 10*time.Millisecond)
+	waitForDictionary(t, pr, sealDictWords)
 	sendStream(t, ac, model.StreamTrace, 0, file1)
 	sendStream(t, ac, model.StreamCalls, 0, wire.CallsStreamRecords(baseMs, calls))
 	waitForIndexedCalls(t, store, bucket, key, 2)


### PR DESCRIPTION
## Why
`TestHotColdFanout` flaked in CI ([run 34501363300](https://github.com/Netcracker/qubership-profiler-agent/actions/runs/34501363300/job/102952679819)) with the A1 params rendered as `{"#4": ["req-1"]}` instead of `{"request.id": ["req-1"]}`. The ingest pipeline appends dictionary words one at a time, each under its own lock acquisition (`PodRestart.AppendDictionaryWord`), and the tests waited only for word 3 (`call.red`) before calling `Store.Seal`. When the seal snapshotted the dictionary between word 3 and word 4, the cold parquet copy of A1 carried the `#4` placeholder, and the cold-preferred dedup then served it. The `error_flag` assertion in the same subtest passed because it depends on word 3 alone.

## What
A shared helper `waitForDictionary(t, pr, words)` waits until the pod-restart's dictionary equals the whole fixture, id by index, and replaces the single-word waits in `coldread_test.go`, `fanout_test.go`, and `janitor_test.go`. The janitor test seals after `Finalized`, which already drains the decoder, so there the change is uniformity rather than a fix.

## Verification
The three tests pass 15 runs in a row, and the package passes once under `-race`. The helper was shown able to fail by appending an extra word to the fixture: `require.EventuallyWithT` prints the expected and actual maps with a diff, then `dictionary of <key> must hold every fixture word`, where the old `require.Eventually` printed only `Condition never satisfied`.

## Scope
Every other `Seal(` call in the package runs after `Finalized` or `waitForCollectorStop`, which wait for the decoder goroutine, so no other site is exposed. The single-word wait in `hotstore_test.go` precedes the calls stream, not a seal, and is left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
