### PR TITLE
fix(build): publish qubership-profiler-bom-thirdparty to Central

### DIFF
--- a/build-logic/publishing/src/main/kotlin/build-logic.java-published-platform.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.java-published-platform.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
     id("java-platform")
+    // nmcp resolves com.gradleup.nmcp:nmcp-tasks from the repositories of each project it publishes
+    id("build-logic.repositories")
     id("build-logic.reproducible-builds")
     id("build-logic.publish-to-central")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,8 @@ val parameters by tasks.registering {
 
 dependencies {
     nmcpAggregation(projects.agent)
+    // The Gradle metadata of every published module depends on this platform, see build-logic.java
+    nmcpAggregation(projects.bomThirdparty)
     nmcpAggregation(projects.boot)
     nmcpAggregation(projects.common)
     nmcpAggregation(projects.cli)


### PR DESCRIPTION
## Why

The Gradle module metadata of every published artifact depends on `org.qubership.profiler:qubership-profiler-bom-thirdparty` with `org.gradle.category=platform` (for example, [qubership-profiler-agent-4.0.5.module](https://repo1.maven.org/maven2/org/qubership/profiler/qubership-profiler-agent/4.0.5/qubership-profiler-agent-4.0.5.module)), but the BOM has never been published to Central: its [maven-metadata.xml](https://repo1.maven.org/maven2/org/qubership/profiler/qubership-profiler-bom-thirdparty/maven-metadata.xml) returns 404. A Gradle consumer of any release fails with `Could not find org.qubership.profiler:qubership-profiler-bom-thirdparty:4.0.5.` Maven consumers are unaffected, since the `.pom` files do not reference the BOM.

The release publishes only the projects listed in `nmcpAggregation`, and `:bom-thirdparty` was not among them.

## What

- `:bom-thirdparty` is added to `nmcpAggregation`. Publishing it, rather than removing it from the published variants, keeps its constraints for consumers: the Jackson, ASM, and Guice BOMs and the rejection of `org.lz4:lz4-java`.
- `build-logic.java-published-platform` now applies `build-logic.repositories`. nmcp resolves `com.gradleup.nmcp:nmcp-tasks` from the repositories of each project it publishes, and without them `nmcpZipAggregation` fails with `Cannot resolve external dependency com.gradleup.nmcp:nmcp-tasks:1.6.1 because no repositories are defined.`

I checked every `.module` in `aggregation.zip`: `bom-thirdparty` is the only `org.qubership.profiler` dependency that was missing from it. `bom-testing` is referenced by no published module (its users `testkit`, `plugin-testkit`, and `jcstress-jupiter-engine` are not released), so it stays unpublished.

## Verification

Built `nmcpZipAggregation` with `-Prelease=true` and a throwaway PGP key; the zip contains a signed `qubership-profiler-bom-thirdparty-4.0.6` `.pom` and `.module`. A throwaway Gradle consumer, taking `org.qubership.profiler` only from a file repository unpacked from the zip, resolves `compileClasspath` and `runtimeClasspath` for all published components. With the BOM directory deleted from that repository, resolution fails with `Could not find org.qubership.profiler:qubership-profiler-bom-thirdparty:4.0.6.`

## Scope

Nothing checks that every platform the published metadata references is itself in the aggregation, so the next such platform would leak the same way; that check is outside this change.

A consumer that depends on both `qubership-profiler-profiler` and `qubership-profiler-war-lib` directly fails on a capability conflict: `profiler` requests `war-lib` with `bundling=shadowed`, and `war-lib` publishes `runtimeElements` and `shadowRuntimeElements` with the same capability. 4.0.5 behaves the same; this change does not address it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
