### PR TITLE
ci: update misspell action to v1.28.0

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -4,8 +4,4 @@ groups:
   - name: rotating
     reviewers: 1
     usernames:
-      - Beauline
       - NikolaiKuziaevQubership
-      - dmitriikazanin
-      - bagwan-shoaib
-      - al-matushkin

--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -4,4 +4,8 @@ groups:
   - name: rotating
     reviewers: 1
     usernames:
+      - Beauline
       - NikolaiKuziaevQubership
+      - dmitriikazanin
+      - bagwan-shoaib
+      - al-matushkin

--- a/.github/workflows/misspell.yaml
+++ b/.github/workflows/misspell.yaml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Run misspell with reviewdog
-        uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1.27.0
+        uses: reviewdog/action-misspell@ba7ac4030fa6812f8c8b2d4e516af8bc99553c32 # v1.28.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           locale: "US"


### PR DESCRIPTION
## Why

Spell Check on merged PR #943 failed twice while building reviewdog/action-misspell v1.27.0 because its Debian Bullseye security metadata was expired.

## What

Update the immutable `reviewdog/action-misspell` pin in `.github/workflows/misspell.yaml` from v1.27.0 to v1.28.0 (`ba7ac4030fa6812f8c8b2d4e516af8bc99553c32`). The released action uses a prebuilt GHCR image pinned by digest and no longer builds the Bullseye Dockerfile in the runner.

All spell-check inputs, permissions, triggers, paths, and failure policy remain unchanged. The reviewer lottery candidate list is unchanged from the base branch.

## Verification

- Parsed the workflow as YAML.
- Confirmed the base-to-head diff changes only `.github/workflows/misspell.yaml`.
- Inspected the official v1.28.0 metadata and Dockerfile at the immutable commit.
- Pulled the released image by its immutable digest successfully.
- Kept APT validity, Spell Check, Reviewer Lottery, and human review gates enabled.